### PR TITLE
error when searching

### DIFF
--- a/www/htdocs/central/dataentry/buscar.php
+++ b/www/htdocs/central/dataentry/buscar.php
@@ -1,6 +1,7 @@
 <?php
 /* Modifications
 20210311 fho4abcd body tag on correct position
+20210326 guilda Error when searching due to quoting
 */
 //error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING);
 session_start();
@@ -53,7 +54,7 @@ global $arrHttp,$db_path,$xWxis,$tagisis,$Wxis,$wxisUrl;
 			if ($vienede=="buscar_en_este" or $vienede=="toolbar"){
 				echo "<script>
 						window.opener.top.browseby=\"search\"
-						window.opener.top.Expresion=".$Expresion."
+						window.opener.top.Expresion='".str_replace("'","¨",$Expresion)."'
 						window.opener.top.mfn=1
 						window.opener.top.Menu(\"ejecutarbusqueda\");
 						self.close()

--- a/www/htdocs/central/dataentry/fmt.php
+++ b/www/htdocs/central/dataentry/fmt.php
@@ -1,4 +1,7 @@
 <?php
+/* Modifications
+2021-03-20 guilda Error when searching due to quoting
+*/
 /**
  * @program:   ABCD - ABCD-Central - http://reddes.bvsaude.org/projects/abcd
  * @copyright:  Copyright (C) 2009 BIREME/PAHO/WHO - VLIR/UOS
@@ -179,6 +182,7 @@ global $arrHttp,$db_path,$xWxis,$Wxis,$valortag,$tl,$nr,$Mfn,$wxisUrl,$lang_db,$
 	$contenido="";
 	$registro="";
 	$IsisScript=$xWxis."buscar_ingreso.xis";
+	$Expresion=str_replace('¨',"'",$Expresion);
 	$query = "&base=".$arrHttp["base"] ."&cipar=$db_path"."par/".$arrHttp["cipar"]."&Expresion=".urlencode($Expresion)."&count=1&from=".$arrHttp["from"]."&Formato=$Formato&prologo=@prologoact.pft&epilogo=@epilogoact.pft";
 	include("../common/wxis_llamar.php");
     $ficha_bib=$contenido;


### PR DESCRIPTION
- buscar.php: updated by guilda
- fmt.php: updated by guilda
- ifpro.php and inicio_main.php : not updated. Content was already in git
Comment Guilda: The problem with search expressions is the following: in HTML double quotes or the apostrophe are used to delimit variables, but both characters are necessary since expressions must be delimited between "..." to allow the and, or and not  to be part of the expression and the ' is used in names and other elements in different languages. I did some changes that can help to solve this issue. Please test.

In version 2.2, the option to enclose each term in the search expression between "..." was added to incorporate the use of and or and not as part of the term. This can cause some problems in some search processes that have not yet been corrected. Please advise.