### PR TITLE
Allow self-signed certificates for server internal operations+get pro…

### DIFF
--- a/www/htdocs/central/common/inc_setup-stream-context.php
+++ b/www/htdocs/central/common/inc_setup-stream-context.php
@@ -1,0 +1,27 @@
+<?php
+/*
+2021-04-02 fho4abcd Created
+Function  : Setup of context options (for e.g. file_get_contents)
+            Context is used when operations in the server are executed via http/https.
+            This setup allows self-signed certificates in server internal calls.
+Usage     : <?php include "../common/inc_setup-stream-context.php" ?>
+            $result=file_get_contents($wxisUrl,false,$context);
+
+    Input : $postdata: The URL for the request NO DEFAULT
+    Output: $context : contains the created context.
+
+The http options specify method, header and content of the request
+The ssl options are for https communication and do not harm if http is used
+*/
+$contextoptsarray =
+    array('http' => array( 'method'  => 'POST',
+                           'header'  => 'Content-type: application/x-www-form-urlencoded',
+                           'content' => $postdata,
+                         ),
+          'ssl'  => array( 'verify_peer'       => true, // default true
+                           'verify_peer_name'  => false,// default true. false required for ss certs
+                           'allow_self_signed' => true, // default false.true required for ss certs
+                          )
+          );
+$context = stream_context_create($contextoptsarray);
+?>

--- a/www/htdocs/central/common/wxis_llamar.php
+++ b/www/htdocs/central/common/wxis_llamar.php
@@ -3,6 +3,7 @@
 20210311 fho4abcd Add workaround in error message WXIS|execution error|file|tmpnam| Error detected on Windows
 20210315 fho4abcd Small textual corrections + removed unused code for mx
 20210315 fho4abcd Display better error message and set $err_wxis in that case too.
+20210402 fho4abcd Code added to allow self-signed certificates for internal server calls
 */
 global $def_db,$server_url, $wxis_exec, $wxisUrl, $unicode,$MULTIPLE_DB_FORMATS,$charset,$cgibin_path,$postMethod,$mx_exec,$meta_encoding,$page_encoding,$def,$arrHttp,$charset;
 unset($contenido);  // This array will get the text of the result
@@ -72,14 +73,7 @@ if (isset($wxisUrl) and $wxisUrl!=""){  //POST method
 
     parse_str($url, $arr_url);
     $postdata = http_build_query($arr_url);
-    $opts = array('http' =>
-                array(
-                        'method'  => 'POST',
-                        'header'  => 'Content-type: application/x-www-form-urlencoded',
-                        'content' => $postdata
-                     )
-                );
-    $context = stream_context_create($opts);
+    include "../common/inc_setup-stream-context.php";
     unset($result);
     unset($con);
     // MAIN POST CONNECTION in following line

--- a/www/htdocs/central/config.php
+++ b/www/htdocs/central/config.php
@@ -6,14 +6,19 @@
 2021-02-10 fho4abcd: new/improved checks $ABCD_path, $db_path, abcd.def
 2021-02-10 fho4abcd: replace fixed server port by autodetection of server port, code formatting
 2021-02-25 fho4abcd: don't send header info (wrong and out of order here)
+2021-04-02 fho4abcd: autodetected protocol (port was already detected since 2021-02-10))
 */
 
 ini_set('error_reporting', E_ALL);
 $cisis_versions_allowed="16-60;ffi;bigisis";
 
 // *** Main server configuration
-// URL with autodetected port
-$server_url="http://localhost:".$_SERVER['SERVER_PORT'];    
+// URL for internal server actions, with autodetected protocol and port
+// Note: protocol/port are determined by server config vhosts file. (also if defaults are used)
+$protocol="http:"; // default protocol
+if ( isset($_SERVER['HTTPS']) and $_SERVER['HTTPS']=="on") $protocol="https:";
+$server_url=$protocol."//localhost:".$_SERVER['SERVER_PORT'];
+
 $postMethod=1;      // if set to '1' (or true) ABCD will use POST-method; if set to '0' the GET-method will be used. Use with caution
 $dirtree=1;         // USE THIS PARAMETER TO SHOW THE ICON THAT ALLOWS THE BASES FOLDER EXPLORATION
 $MD5=0;             // USE THIS PARAMETER TO ENABLE/DISABLE THE MD5 PASSWORD ENCRIPTYON (0=OFF 1=ON)

--- a/www/htdocs/central/test/wxis.php
+++ b/www/htdocs/central/test/wxis.php
@@ -1,4 +1,7 @@
 <?php
+/* modifications
+20210402 fho4abcd Added test with context
+*/
 include("../config.php");
 echo "<xmp>";
 echo "Path to databases: $db_path--\n";
@@ -10,20 +13,28 @@ echo "<hr>";
 echo "Testing if the  file <b>$Wxis</b> exists<br>";
 if  (!file_exists($Wxis)){
 	echo "missing $Wxis";
-	die;
+	//die;
 }
-echo "Result: <b>Ok !!!</b><p>";
+//echo "Result: <b>Ok !!!</b><p>";
 
 if ($wxisUrl!=""){
 	echo "<hr>";
-	echo "<font color=blue>Testing the execution of  <b>$wxisUrl</b> via Http</font><br>";
+	echo "<font color=blue>Testing the execution of  <b>$wxisUrl</b> via http(s), NO context</font><br>";
 	echo "$wxisUrl?IsisScript=$xWxis".'hello.xis';
 	$result =file_get_contents($wxisUrl."?IsisScript=$xWxis".'hello.xis');
 	echo $result;
 
+	echo "<hr>";
+	echo "<font color=blue>Testing the execution of  <b>$wxisUrl</b> via http(s), WITH context</font><br>";
+	echo "$wxisUrl?IsisScript=$xWxis".'hello.xis';
+    $postdata="IsisScript=$xWxis".'hello.xis'; // $ postdata required by inc_setup-stream-contxt
+    include "../common/inc_setup-stream-context.php";
+	$result =file_get_contents($wxisUrl,false,$context);
+	echo $result;
+
 	//-----------------------------------------------------
 	echo "<p><hr>";
-	echo "<font color=blue>Testing the acces to the operator's database (acces) using http</font><p>";
+	echo "<font color=blue>Testing the acces to the operator's database (acces) using http(s)</font><p>";
 	$IsisScript=$xWxis."login.xis";
 	$query = "&base=acces&cipar=$db_path"."par/acces.par"."&login=abcd&password=adm";
 	include("../common/wxis_llamar.php");


### PR DESCRIPTION
…tocol info from vhosts file

- config.php: retrieve http/https from vhosts file. Effect is that port or protocol changes do not require an update of config.php.
- inc_setup-stream-context.php (new): code fragment to setup streaming context.  Includes allowance of self-signed certificates (server internal!).
- wxis_llamar.php: moved context setup to inc_setup-stream-contxt.php
-test/wxis.exe: added extra test case for context