### PR TITLE
Unify sources for inverted file creation

### DIFF
--- a/www/htdocs/central/dataentry/wxis/fullinv.xis
+++ b/www/htdocs/central/dataentry/wxis/fullinv.xis
@@ -1,4 +1,5 @@
 <IsisScript name="fullinv">
+<!-- 20210408 fho4abcd Added newlines in feedback -->
 <section name="fullinversion">
 
 <function name="status" action="replace" tag="2001">
@@ -38,10 +39,10 @@
 		<field action="replace" tag="2004"><pft>v5001,'.fst'</pft></field>
 		<parm name="fst"><pft>cat(v2004)</pft></parm>
 		<field action="define" tag="1102">Isis_Status</field>
-		<display><pft>'Full invertion: ',v5001/</pft></display>
+		<display><pft>'Full invertion: ',v5001,'<br>'/</pft></display>
 		<loop>
 		</loop>
-	     <display><pft>'Finished.'/</pft></display>
+	     <display><pft>'Finished.<br>'/</pft></display>
     	 <display><pft>'Lock status = 'v1102'<br>' if v1102='8' then ' No se ejecutó la actualización. Debe desbloquear la base de datos' fi/</pft></display>
   </do>
 

--- a/www/htdocs/central/utilities/show_par_file.php
+++ b/www/htdocs/central/utilities/show_par_file.php
@@ -1,0 +1,29 @@
+<?php
+/*
+** 20210405 fho4abcd Created
+** Function: Lists the content of file given by parameter 'par_file'
+**           No check if file exists: done by caller
+** Example : show_parfile.php?par_file=/var/www/abcd22/www/bases/par/fredstest_unicode.par
+*/
+include("../common/get_post.php");
+include("../config.php");
+include("../common/header.php");
+$par_file=$arrHttp["par_file"];
+?>
+<div class="sectionInfo">
+<h3 align="center"><?php echo "Database parameter file = <br>".$par_file;?></h3>
+
+<div class="middle form">
+<div  style='margin-left: 10px'>
+<br>
+<?php
+$handle = fopen($par_file, "r");
+if ($handle) {
+    while (($buffer = fgets($handle)) !== false) {
+        echo $buffer."<br>";
+    }
+    fclose($handle);
+}
+?>
+</div>
+</div>


### PR DESCRIPTION
Interactive updates use the files indicated by <dbn>.par. The menu items to regenerate had fixed filenames. This commit resolves this.
- vmx-fullinv.php: reads parameters from <dbn>.par now.
- show_par.php: link to show <dbn>.par in pop-up, just like the test-mx button
- fullinv.xis: output on distinct lines (no relation with other items in this commit)