### PR TITLE
Improve switching charactersets with a mix of utf-8/iso databases

### DIFF
--- a/www/htdocs/central/common/institutional_info.php
+++ b/www/htdocs/central/common/institutional_info.php
@@ -2,6 +2,7 @@
 /* Modifications
 20210312 fho4abcd show also charset if different from metaencoding
 20210312 logout without [] to visually detect this script
+20210415 fho4abcd Show db characterset if available, otherwise meta characterset. No longer show difference
 */
 ?>
 <div class="heading">
@@ -15,22 +16,26 @@
 	</div>
 	<div class="userInfo">
 		<span><?php if (isset($_SESSION["nombre"])) echo $_SESSION["nombre"]?></span>,
-		<?php if (isset($_SESSION["profile"])) {			 		echo $_SESSION["profile"]."|";
+		<?php if (isset($_SESSION["profile"])) {
+			 		echo $_SESSION["profile"]."|";
 					$dd=explode("/",$db_path);
                		if (isset($dd[count($dd)-2])){
 			   			$da=$dd[count($dd)-2];
 			   			echo " (".$da.") ";
 					}
 			  }
-              if ( $meta_encoding == $charset ) {
-                  echo " | ".$meta_encoding;
+              if ( isset( $charset )) {
+                  echo " | ".$charset;
               } else {
-                  echo " | ".$meta_encoding." / ".$charset;
+                  echo " | ".$meta_encoding;
               }
 		?> |
 <?php
 
-if (isset($_SESSION["newindow"]) or isset($arrHttp["newindow"])){	echo "<a href='javascript:top.location.href=\"../dataentry/logout.php\";top.close()' xclass=\"button_logout\"><span>[logout]</span></a>";}else{	echo "<a href=\"../dataentry/logout.php\" xclass=\"button_logout\"><span>logout</span></a>";
+if (isset($_SESSION["newindow"]) or isset($arrHttp["newindow"])){
+	echo "<a href='javascript:top.location.href=\"../dataentry/logout.php\";top.close()' xclass=\"button_logout\"><span>[logout]</span></a>";
+}else{
+	echo "<a href=\"../dataentry/logout.php\" xclass=\"button_logout\"><span>logout</span></a>";
 }
 ?>
 	</div>

--- a/www/htdocs/central/config.php
+++ b/www/htdocs/central/config.php
@@ -7,6 +7,7 @@
 2021-02-10 fho4abcd: replace fixed server port by autodetection of server port, code formatting
 2021-02-25 fho4abcd: don't send header info (wrong and out of order here)
 2021-04-02 fho4abcd: autodetected protocol (port was already detected since 2021-02-10))
+2021-04-15 fho4abcd: Send header info to server. (revert 2021-02-25)
 */
 
 ini_set('error_reporting', E_ALL);
@@ -74,17 +75,6 @@ $img_path=$db_path;                        // legacy path to the folder where th
 $cgibin_path=$ABCD_path."www/cgi-bin/";    // path to the basic directory for CISIS-utilities
 $xWxis=$ABCD_path."www/htdocs/$app_path/dataentry/wxis/";    // path to the wxis scripts .xis for Central
 
-//para leer los parámetros reales de configuracion
-/*if (file_exists("config_vars.php"))
-	include("config_vars.php");
-else
-	if (file_exists("../config_vars.php"))
-		include("../config_vars.php");
-	else
-		if (file_exists("central/config_vars.php"))
-			include("central/config_vars.php");
-*/
-
 $unicode="";
 $institution_name="";
 $cisis_ver=""; // initialisation of $cisis_ver as empty = default standard CISIS-version
@@ -141,6 +131,9 @@ if (file_exists(realpath(dirname(__FILE__)).DIRECTORY_SEPARATOR."config_extended
 	$def["UNICODE"]=0;
 	$charset="ISO-8859-1";
 }
+// Send characterset to the server. Note that the browser gets it via the html header.
+header('Content-type: text/html; charset=$charset');
+
 if (session_status() != PHP_SESSION_NONE )  $_SESSION["meta_encoding"]=$meta_encoding;
 
 //SE CAMBIA EL LENGUAJE POR DEFECTO POR EL QUE SE ESTABLEZCA EN abcd.def

--- a/www/htdocs/central/dataentry/inicio_base.php
+++ b/www/htdocs/central/dataentry/inicio_base.php
@@ -2,6 +2,7 @@
 /* Modifications
 2021-03-02 fho4abcd Replaced helper code fragment by included file
 2021-03-15 fho4abcd Replaced dbinfo code by included file
+2021-04-15 fho4abcd use charset from config.php
 */
 session_start();
 if (!isset($_SESSION["permiso"])){
@@ -72,13 +73,17 @@ if (!isset($arrHttp["inicio"])){   //indica que no se van a colocar los formatos
 	echo "if (top.ModuloActivo==\"catalog\") top.menu.document.forma1.formato.options.length=0\n";
 	$i=-1;
 	if (isset($fp)) {
-		foreach($fp as $linea){			if (trim($linea)!="") {				$linea=trim($linea);
+		foreach($fp as $linea){
+			if (trim($linea)!="") {
+				$linea=trim($linea);
 				$ll=explode('|',$linea);
 				$cod=$ll[0];
 				$nom=$ll[1];
 				if (isset($_SESSION["permiso"][$arrHttp["base"]."_pft_ALL"]) or isset($_SESSION["permiso"][$arrHttp["base"]."_pft_".$ll[0]]) or isset($_SESSION["permiso"][$arrHttp["base"]."_CENTRAL_ALL"])
-						or isset($_SESSION["permiso"]["CENTRAL_ALL"])){					$i=$i+1;
-					echo "if (top.ModuloActivo==\"catalog\") top.menu.document.forma1.formato.options[$i]=new Option('$nom','$cod')\n";				}
+						or isset($_SESSION["permiso"]["CENTRAL_ALL"])){
+					$i=$i+1;
+					echo "if (top.ModuloActivo==\"catalog\") top.menu.document.forma1.formato.options[$i]=new Option('$nom','$cod')\n";
+				}
 			}
 		}
 
@@ -93,13 +98,16 @@ if (!isset($arrHttp["inicio"])){   //indica que no se van a colocar los formatos
 	//Se leen las hojas de entrada disponibles
 	if (file_exists($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/formatos.wks")){
 		$fp = file($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/formatos.wks");
-	}else{		if (file_exists($db_path.$arrHttp["base"]."/def/".$lang_db."/formatos.wks"))
-			$fp = file($db_path.$arrHttp["base"]."/def/".$lang_db."/formatos.wks");	}
+	}else{
+		if (file_exists($db_path.$arrHttp["base"]."/def/".$lang_db."/formatos.wks"))
+			$fp = file($db_path.$arrHttp["base"]."/def/".$lang_db."/formatos.wks");
+	}
 	$i=0;
 	$wks_p=array();
 	if (isset($fp)) {
 		foreach($fp as $linea){
-			if (trim($linea)!="") {				$linea=trim($linea);
+			if (trim($linea)!="") {
+				$linea=trim($linea);
 				$l=explode('|',$linea);
 				$cod=trim($l[0]);
 				$nom=trim($l[1]);
@@ -117,20 +125,25 @@ if (!isset($arrHttp["inicio"])){   //indica que no se van a colocar los formatos
 	unset($fp);
 	if (file_exists($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/typeofrecord.tab")){
 		$fp = file($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/typeofrecord.tab");
-	}else{		if (file_exists($db_path.$arrHttp["base"]."/def/".$lang_db."/typeofrecord.tab"))
-			$fp = file($db_path.$arrHttp["base"]."/def/".$lang_db."/typeofrecord.tab");	}
+	}else{
+		if (file_exists($db_path.$arrHttp["base"]."/def/".$lang_db."/typeofrecord.tab"))
+			$fp = file($db_path.$arrHttp["base"]."/def/".$lang_db."/typeofrecord.tab");
+	}
 	$i=0;
 	$typeofr="";
 	if (isset($fp)) {
-		foreach($fp as $linea){	           if ($i==0){
+		foreach($fp as $linea){
+	           if ($i==0){
 	           	$l=explode(" ",$linea);
 	           	echo "top.tl='".trim($l[0])."'\n";
 	           	if (isset($l[1]))
 	           		echo "top.nr='".trim($l[1])."'\n";
 	           	else
 	           	    echo "top.nr=''\n";
-	           	$i=1;	           }else{
-				if (trim($linea)!="") {					$l=explode('|',$linea);
+	           	$i=1;
+	           }else{
+				if (trim($linea)!="") {
+					$l=explode('|',$linea);
 					$cod=$l[0];
 					$ix=strpos($cod,".");
 					$cod=substr($cod,0,$ix);
@@ -140,7 +153,9 @@ if (!isset($arrHttp["inicio"])){   //indica que no se van a colocar los formatos
 			}
 		}
 		echo "top.typeofrecord=\"$typeofr\"\n";
-	}else{		echo "top.typeofrecord=\"\"\n";	}
+	}else{
+		echo "top.typeofrecord=\"\"\n";
+	}
 }
 
 //Se lee la fdt para determinar el prefijo y el formato de extracción del campo del índice de la entrada principal
@@ -165,9 +180,12 @@ foreach($fp as $linea){
 		$fdt=explode('|',$linea);
 		if ($fdt[7]=="B") $HTML=$fdt[1];  //LOAD EXTERNAL TEXT FILE  IN THIS TAG
 		if ($fdt[7]=="H") $URL=$fdt[1];   //URL TO TH DOCUMENT LOADED IN $HTML
-		if ($fdt[3]==1){                  //MAIN FIELD ALPHABETIC INDEX			$pi=$fdt[12];
+		if ($fdt[3]==1){                  //MAIN FIELD ALPHABETIC INDEX
+			$pi=$fdt[12];
 			$fe=$fdt[13];
-			if (trim($fe=="")){				$fe="v".trim($fdt[1]);			}
+			if (trim($fe=="")){
+				$fe="v".trim($fdt[1]);
+			}
 		}
 	}
 }
@@ -177,12 +195,15 @@ html='$HTML'
 url='$URL'
 top.prefijo_indice='$pi'
 top.formato_indice='".urlencode($fe)."'
-if (html=='' && top.HTML==''){        //No changes in the toolbar}else{
+if (html=='' && top.HTML==''){        //No changes in the toolbar
+
+}else{
 	top.HTML='$HTML'
 	top.URL='$URL'
 	top.lock_db=\"\"
 	top.menu.location.href=\"menu_main.php?base=\"+top.base+\"&reload=N\"
-}</script>";
+}
+</script>";
 
 
 ?>
@@ -194,27 +215,25 @@ if (html=='' && top.HTML==''){        //No changes in the toolbar}else{
 <br><br><br>
 <?php
 echo "<center><b>".$msgstr["bd"].": ".$arrHttp["base"]."</b>";
-if ( !isset($def_db["UNICODE"]) or $def_db["UNICODE"] == "ansi" || $def_db["UNICODE"] == '0' ) {
-	$charset_db="ISO-8859-1";
-}else{
-	$charset_db="UTF-8";
-}
-echo "<br><strong>$charset_db</strong>" ;
+echo "<br><strong>$charset</strong>" ;
 echo "<br><b><font color=darkred>". $msgstr["maxmfn"].": ".$arrHttp["MAXMFN"]."</b></font>";
 
 if ($arrHttp["BD"]=="N")
 	echo "<p>".$msgstr["database"]." ".$msgstr["ne"];
 if ($arrHttp["IF"]=="N")
 	echo "<p>".$msgstr["if"]." ".$msgstr["ne"];
-if ($arrHttp["EXCLUSIVEWRITELOCK"]!=0) {	echo "<p>".$msgstr["database"]." ".$msgstr["exwritelock"]."=".$arrHttp["EXCLUSIVEWRITELOCK"].". ".$msgstr["contactdbadm"]."
+if ($arrHttp["EXCLUSIVEWRITELOCK"]!=0) {
+	echo "<p>".$msgstr["database"]." ".$msgstr["exwritelock"]."=".$arrHttp["EXCLUSIVEWRITELOCK"].". ".$msgstr["contactdbadm"]."
 	<script>top.lock_db='Y'</script>
 	";
-}
+
+}
 echo $warning;
 
 if ($wxisUrl!=""){
 	echo "<p>CISIS version: $wxisUrl</p>";
-}else{	$ix=strpos($Wxis,"cgi-bin");
+}else{
+	$ix=strpos($Wxis,"cgi-bin");
 	$wxs=substr($Wxis,$ix);
     echo "<p>CISIS version: ".$wxs."</p>";
 }

--- a/www/htdocs/central/dataentry/menubases.php
+++ b/www/htdocs/central/dataentry/menubases.php
@@ -1,4 +1,7 @@
 <?php
+/* Modifications
+2021-04-15 fho4abcd use charset from config.php+show charsets like institutional_info.php
+*/
 //error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING);
 global $valortag;
 session_start();
@@ -24,20 +27,12 @@ if (!$fp){
 	echo "falta el archivo bases.dat";
 	die;
 }
-
-if ( !isset($def["UNICODE"]) or $def["UNICODE"] == "ansi" || $def["UNICODE"] == '0' ) {
-	$unicode='ansi';
-	$charset="ISO-8859-1";
-} else {
-	$unicode='utf8';
-	$charset="UTF-8";
-}
-$meta_encoding=$charset;
 include("../common/header.php");
 echo "<script>
 top.listabases=Array()
 top.basesdat=Array()\n";
-foreach ($fp as $linea){	$linea=trim($linea);
+foreach ($fp as $linea){
+	$linea=trim($linea);
 	if ($linea!="") {
 		$ix=strpos($linea,"|");
 		$ix_bb=explode('|',$linea);
@@ -126,7 +121,8 @@ function CambiarBase(){
 	}
 }
 
-function Modulo(){	Opcion=document.OpcionesMenu.modulo.options[document.OpcionesMenu.modulo.selectedIndex].value
+function Modulo(){
+	Opcion=document.OpcionesMenu.modulo.options[document.OpcionesMenu.modulo.selectedIndex].value
 	switch (Opcion){
 		case "loan":
 			top.location.href="../common/change_module.php?modulo=loan"
@@ -144,7 +140,11 @@ function Modulo(){	Opcion=document.OpcionesMenu.modulo.options[document.Opcione
 			top.main.location.href="inicio_base.php?inicio=s&base="+base+"&cipar="+base+".par"
 			top.menu.location.href="../dataentry/menu_main.php?Opcion=continue&cipar=acces.par&cambiolang=S&base="+base
 			top.ModuloActivo="catalog"
-			if (i>0) {				top.menu.location.href="../dataentry/menu_main.php?Opcion=continue&cipar=acces.par&cambiolang=S&base="+base			}else{				top.menu.location.href="../dataentry/blank.html"			}
+			if (i>0) {
+				top.menu.location.href="../dataentry/menu_main.php?Opcion=continue&cipar=acces.par&cambiolang=S&base="+base
+			}else{
+				top.menu.location.href="../dataentry/blank.html"
+			}
 			break
 
 
@@ -195,7 +195,11 @@ function CambiarLenguaje(){
 			   		$da=$dd[count($dd)-2];
 			   		echo " (".$da.") ";
 				}
-				echo " | $meta_encoding ";
+              if ( isset( $charset )) {
+                  echo " | ".$charset;
+              } else {
+                  echo " | ".$meta_encoding;
+              }
 		?> |
 		<?php echo $_SESSION["profile"]?> |
 <?php
@@ -213,7 +217,8 @@ $circulation="";
 $acquisitions="";
 foreach ($_SESSION["permiso"] as $key=>$value){
 	$p=explode("_",$key);
-	if (isset($p[1]) and $p[1]=="CENTRAL") $central="Y";	if (substr($key,0,8)=="CENTRAL_")  $central="Y";
+	if (isset($p[1]) and $p[1]=="CENTRAL") $central="Y";
+	if (substr($key,0,8)=="CENTRAL_")  $central="Y";
 	if (substr($key,0,5)=="CIRC_")  $circulation="Y";
 	if (substr($key,0,4)=="ACQ_")  $acquisitions="Y";
 
@@ -239,7 +244,8 @@ if ($circulation=="Y" or $acquisitions=="Y"){
 		foreach ($fp as $value){
 
 			$value=trim($value);
-			if ($value!=""){				$l=explode('=',$value);
+			if ($value!=""){
+				$l=explode('=',$value);
 				if ($l[0]!="lang"){
 					if ($l[0]==$_SESSION["lang"]) $selected=" selected";
 					echo "<option value=$l[0] $selected>".$msgstr[$l[0]]."</option>";
@@ -264,8 +270,10 @@ foreach ($lista_bases as $key => $value) {
 	$t=explode('|',$value);
 	if (isset($_SESSION["permiso"]["db_".$key]) or isset($_SESSION["permiso"]["db_ALL"]) or isset($_SESSION["permiso"]["CENTRAL_ALL"]) or  isset($_SESSION["permiso"][$key."_CENTRAL_ALL"])){
 		if (isset($arrHttp["base_activa"])){
-			if ($key==$arrHttp["base_activa"]) 	{				$xselected=" selected";
-				if (isset($t[1])) $hascopies=$t[1];			}
+			if ($key==$arrHttp["base_activa"]) 	{
+				$xselected=" selected";
+				if (isset($t[1])) $hascopies=$t[1];
+			}
 
 		}
 		if (!isset($t[1])) $t[1]="";
@@ -273,7 +281,9 @@ foreach ($lista_bases as $key => $value) {
 	}
 }
 echo "</select>" ;
-if ($hascopies=="Y" and (isset($_SESSION["permiso"]["CENTRAL_ADDCO"]) or isset($_SESSION["permiso"]["CENTRAL_ALL"]) or  isset($_SESSION["permiso"][$arrHttp["base"]."_CENTRAL_ALL"]) or isset($_SESSION["permiso"][$arrHttp["base"]."_CENTRAL_ADDCO"]))){	echo "\n<script>top.db_copies='Y'\n</script>\n";}
+if ($hascopies=="Y" and (isset($_SESSION["permiso"]["CENTRAL_ADDCO"]) or isset($_SESSION["permiso"]["CENTRAL_ALL"]) or  isset($_SESSION["permiso"][$arrHttp["base"]."_CENTRAL_ALL"]) or isset($_SESSION["permiso"][$arrHttp["base"]."_CENTRAL_ADDCO"]))){
+	echo "\n<script>top.db_copies='Y'\n</script>\n";
+}
 ?>
 	</div>
 

--- a/www/htdocs/central/dbadmin/menu_mantenimiento.php
+++ b/www/htdocs/central/dbadmin/menu_mantenimiento.php
@@ -4,6 +4,7 @@
 20210314 fho4abcd html move body and remove win.close + sanitize html
 20210314 fho4abcd Replaced dbinfo code by included file
 20210324 fho4abcd Catch error after database deletion, display also long name of the database
+20210415 fho4abcd use charset from config.php
 */
 session_start();
 
@@ -46,7 +47,8 @@ foreach ($fp as $value){
 	$value=trim($value);
 	$x=explode("|",$value);
 	if ($x[0]==$arrHttp["base"]){
-		if (isset($x[2]) and $x[2]=="Y"){			$copies="Y";
+		if (isset($x[2]) and $x[2]=="Y"){
+			$copies="Y";
 		}
 		break;
 	}
@@ -98,13 +100,7 @@ if ( isset($arrHttp["base"]) and $arrHttp["base"]!="" and file_exists($db_path.$
     echo "<br><font color=darkred><b>". $msgstr["dbnex"]."</b></font><br>";
     $arrHttp["MAXMFN"]="?";
 }
-
-if ( !isset($def_db["UNICODE"]) or $def_db["UNICODE"] == "ansi" || $def_db["UNICODE"] == '0' ) {
-	$charset_db="ISO-8859-1";
-}else{
-	$charset_db="UTF-8";
-}
-echo "<br><strong>$charset_db</strong>" ;
+echo "<br><strong>$charset</strong>" ;
 echo "<br><font color=darkred><b>". $msgstr["maxmfn"].": ".$arrHttp["MAXMFN"]."</b></font>";
 
 if (isset($arrHttp["BD"]) and $arrHttp["BD"]=="N")


### PR DESCRIPTION
Switching between databases with different charactersets did not work nice. Caused by bad feedback (due to different methods to display it) and the removal of the "header" clause in config.php (my fault). This commit improves this for the basic operations.
- homepage.php: Show charsets like institutional_info.php + show new value if database is changed immediately
- institutional_info.php: show only the current charset.
- config.php: Execute php "header"direct after determination of the characterset (statement was accidentally removed in a previous commit)
- inicio_base.php: Use charset inherited from config.php
- menu_bases.php: Use charset inherited from config.php+ show like institutional_info.php
- menu_mantenimiento.php: Use charset inherited from config.php