### PR TITLE
Bugs when logged in as emergency user

### DIFF
--- a/www/htdocs/central/common/inicio.php
+++ b/www/htdocs/central/common/inicio.php
@@ -2,6 +2,7 @@
 /* Modifications
 2021-01-05 guilda Removed login encryption
 2021-01-05 LeerRegistro compares the password
+2021-04-21 fho4abcd Show a an emergency user name if applicable
 */
 global $Permiso, $arrHttp,$valortag,$nombre;
 $arrHttp=Array();
@@ -112,6 +113,7 @@ Global $arrHttp,$valortag,$Path,$xWxis,$session_id,$Permiso,$msgstr,$db_path,$no
         }else{        	unset ($_SESSION["library"]);        }
  	}else{
  		if ($arrHttp["login"]==$adm_login and $arrHttp["password"]==$adm_password){ 			$Perfil="adm";
+  		    $nombre="!!Emergency/Emergencia!!"; // The displayed name of the emergency user
  			unset($_SESSION["profile"]);
     		unset($_SESSION["permiso"]);
     		unset($_SESSION["login"]);

--- a/www/htdocs/central/dataentry/inicio_main.php
+++ b/www/htdocs/central/dataentry/inicio_main.php
@@ -1,6 +1,7 @@
 <?php
 /* Modifications
 2021-03-03 fho4abcd Replaced header code by standard include
+2021-04-21 fho4abcd Do not crash if emergency user logs in: allows update of databases by emergency user
 */
 //error_reporting(E_ALL);
 session_start();
@@ -112,7 +113,12 @@ if (isset($arrHttp["base"])){
 	$arrHttp["IsisScript"]="control.xis";
 	$llave=LeerRegistro();
 	$stat=explode('|',$llave);
-	$llave=substr($stat[2],7);
+	if (isset($stat[2])) {
+        $llave=substr($stat[2],7);
+    } else {
+        // if the user is not found (emergency user) set ridiculous value
+        $llave="r1dicul0uS";
+    }
 	if (!isset($bdright)) $bdright="";
 	if (!isset($db_copies)) $db_copies="";
 	if (!isset($bddesc)) $bddesc="";

--- a/www/htdocs/central/dataentry/menubases.php
+++ b/www/htdocs/central/dataentry/menubases.php
@@ -1,6 +1,7 @@
 <?php
 /* Modifications
 2021-04-15 fho4abcd use charset from config.php+show charsets like institutional_info.php
+2021-04-21 fho4abcd no undefined index for emergency user.
 */
 //error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING);
 global $valortag;
@@ -20,7 +21,12 @@ include ("../lang/lang.php");
 include("leerregistroisispft.php");
 
 $arrHttp["IsisScript"]="ingreso.xis";
-$arrHttp["Mfn"]=$_SESSION["mfn_admin"];
+if (isset($_SESSION["mfn_admin"])){
+    $arrHttp["Mfn"]=$_SESSION["mfn_admin"];
+} else {
+    //Pointing to a user mfn in the acces database is not good.
+    //The fake name is set in inicio.php
+}
 
 $fp = file($db_path."bases.dat");
 if (!$fp){


### PR DESCRIPTION
In config.php a login for an emergency user can be specified. This commit solves some  bugs in related code.
- inicio.php: Show in the toprow  some text to indicate that this is the emergency user
- inicio_main.php: Do not crash when the user is the emergency user
- menubases.php: Don't show warning for undefined index for the emergency user