### PR TITLE
Check line-ends for ISO files.

### DIFF
--- a/www/htdocs/central/utilities/inc_check-line-end.php
+++ b/www/htdocs/central/utilities/inc_check-line-end.php
@@ -1,0 +1,51 @@
+<?php
+/* Modifications
+20210426 fho4abcd Created
+*/
+
+/*--------------------------------------------------------------
+** Function  : Checks the line ending of the given file
+**             The line-ends must fit the current operating system
+**             In case of wrong lineends the function will die with a message to correct it
+**             Only the first line-end ic checked. It is assumed that the rest is the same.
+** Usage     : include "inc_check-line-end.php";
+**             if ( check_line_end($file) != 0 ) // error processing
+** Parameters: - $filename : full path of file to check
+** Returns   : 0 : no errors occured. linenends match
+**             1 : error reading the file
+**             2 : line-ends mismatch
+** Messages  : Shows a message if lineends are correct and a failure message in case of errors
+*/
+// 
+function check_line_end($filename) {
+    global $msgstr;
+    $retval=0;
+    // Test for correct lineendings: mx will fail with wrong lineends
+    $actlinend="";$strlinend="?";$oslinend="??";
+    $handle = @fopen($filename, "r");
+    if ($handle) {
+        while (($line = fgets($handle)) !== false) {
+            // process the line read.
+            if ( strpos($line,"\r\n") !== false) { $strlinend="CRLF";$actlinend="\r\n";break;}
+            if ( strpos($line,"\r")   !== false) { $strlinend="CR";$actlinend="\r";break;}
+            if ( strpos($line,"\n")   !== false) { $strlinend="LF";$actlinend="\n";break;}
+        }
+
+        fclose($handle);
+    } else {
+        $contents_error= error_get_last();
+        echo "<font color=red>".$msgstr["copenfile"]." <b>".$filename.":</b> ".$contents_error["message"]."</font><br><br>";
+        return 1;
+    }
+    if (strcmp(PHP_EOL,"\r\n")==0) $oslinend="CRLF";
+    if (strcmp(PHP_EOL,"\r")==0)   $oslinend="CR";
+    if (strcmp(PHP_EOL,"\n")==0)   $oslinend="LF";
+    if (strcmp(PHP_EOL,$actlinend)==0) {
+        echo "Line endings of file $filename: $strlinend &rarr; OK";
+        return 0;
+    } else {
+        echo "<font color=red>".$msgstr["fatal"].": Line endings of file $filename: <b>$strlinend</b> &rarr; Please correct to <b>$oslinend</b></font>";
+        return 2;
+    }
+ return $retval;
+}

--- a/www/htdocs/central/utilities/mx_show_iso.php
+++ b/www/htdocs/central/utilities/mx_show_iso.php
@@ -1,6 +1,7 @@
 <?php
 /* Modifications
 2021-04-20 fho4abcd Created from readiso_mx and reduce functionality to iso files
+2021-04-26 fho4abcd Check line endings
 */
 /*
 ** Shows the content of an .iso file o file by mx
@@ -25,6 +26,8 @@
 **
 ** mx does not honour the "from" clause for iso files.(Bug?)
 ** The code reads always all (to "to") records and skips the display up to the "from" record.
+**
+** mx requires the correct line endings. This is checked in advance.
 */
 error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING);
 session_start();
@@ -157,6 +160,10 @@ $arrHttp["toiso"]=$arrHttp["fromiso"]+$count;
 <?php
 // $db is the full path of the file (iso/mst) to list
 $db=$db_path.$arrHttp["storein"]."/".$arrHttp["copyname"];
+
+// Check that the lineends fit with the current OS (mx requirement)
+include "inc_check-line-end.php";
+if ( check_line_end($db)!=0) die; // cannot continue
 
 // set excutable dependent on displayed characterset
 // See config php

--- a/www/htdocs/central/utilities/vmx_import_iso.php
+++ b/www/htdocs/central/utilities/vmx_import_iso.php
@@ -3,6 +3,7 @@
 20210418 fho4abcd Created as replacement for all iso import functions.
 20210421 fho4abcd Show iso files with mx_show_iso
 20210421 fho4abcd No error if an inspected file has no extension
+2021-04-26 fho4abcd Check line endings
 */
 global $arrHttp;
 set_time_limit(0);
@@ -179,6 +180,9 @@ if ($confirmcount<=0) {  /* - First screen: Select the iso file -*/
         echo "</table>";
     }
 } else if ($confirmcount==1) {  /* - Second screen: Present a menu with parameters -*/
+    // Check that the lineends fit with the current OS (mx requirement)
+    include "inc_check-line-end.php";
+    if ( check_line_end($fullisoname)!=0) die; // cannot continue
     ?>
     <table  cellspacing=5>
         <tr>


### PR DESCRIPTION
Utility mx can import or show iso files but the line-endings must match the operating system. In case of mismatch various errors are shown but no hint that the root cause is due to the wrong line-end.
- inc_check-line-end.php: new function to detect the line ends and check with the OS.
- mx_show_iso.php: call check function and die if  result is not ok
- vmx_import.php:  call check function and die if  result is not ok