### PR TITLE
Update read_msg.php

### DIFF
--- a/www/htdocs/central/lang/read_msg.php
+++ b/www/htdocs/central/lang/read_msg.php
@@ -1,38 +1,83 @@
 <?php
+/* Modifications
+20210430 fho4abcd Encode only the value, not the key (used by the code)
+20210430 fho4abcd Encode to UTF-8 only for UTF-8 and if the value is not UTF-8
+20210430 fho4abcd Optimize flow: coding activities only if the key is not present in $msgstr
+*/
+/*
+Function:
+    Read a message file into associative array $msgstr
+    Requires $msg_tab for the message file name
+    Requires $msg_path, $db_path, $_SESSION["lang"] to select the file location
+    Requires $charset for ISO-8859-1/UTF-8 selection
+Usage: include "read_msg.php"
+Fileformat: lines with <key>=<message>
+*/
+/* Comments on coding issues
+- Strings may contain " and ' characters.
+  When present " confuses current javascript encoding. ' is not tested extensively but can fail
+  Conversion into html codes &#34;/&quot; and &#39;/&apos; can solve this
+  Effect on display: shows these strings in html:OK, in javascript alerts:NOTOK
+  In order to be safe: Conversion applied. Replacement is UTF-8 safe
+
+- A html page (or frame if used) can contain only 1 character encoding.
+  == developer conflict: The database can be in code X and the language files in code Y
+
+- ISO   language files can be used for ISO databases
+- UTF-8 language files can be used for UTF-8 databases.
+- ISO   language files can be converted to UTF-8 for working with UTF-8 databases
+  The reverse is practically impossible
+
+- ABCD has currently no option to enforce a language encoding driven by database encoding
+
+- Files do not have an indicator of their encoding (and may use mixed encodings).
+  A user indicator (like a filename with suffix "utf8") is not (yet) trusted in this code release
+*/
 if (isset($msg_path) and $msg_path!="")
 	$path=$msg_path;
 else
 	$path=$db_path;
+
+// Process the language specific file
 $a=$path."lang/".$_SESSION["lang"]."/$msg_tab";
-//if (!file_exists($a)){//	 echo $a. " no existe";
-//	 die;
-//}
 if (file_exists($a)) {
 	$fp=file($a);
 	foreach($fp as $var=>$value){
-		if (trim($value)!="") {			$value=str_replace('"','&#34;',$value);
-			$value=str_replace("'",'&#39;',$value);
-			//echo $charset;
-			if ($charset=="UTF-8" and strpos($_SESSION["lang"],"_utf8")===false )
-				$value=utf8_encode($value);
-			$m=explode('=',$value,2);
-			$m[0]=trim($m[0]);
-			if (!isset($msgstr[$m[0]]))$msgstr[$m[0]]=trim($m[1]);
-		}
+        if (trim($value)!="") {            $m=explode('=',$value,2);
+            $key=trim($m[0]);
+            if (!isset($msgstr[$key]) and isset($m[1]) and trim($m[1]!="")) {
+                $value=$m[1];
+                $value=str_replace('"','&quot;',$value);
+                $value=str_replace("'",'&apos;',$value);
+                if ($charset=="UTF-8") {
+                    if (!mb_check_encoding($value,'UTF-8')) {
+                        $value=mb_convert_encoding($value,'UTF-8','ISO-8859-1');
+                    }
+                }
+                $msgstr[$key]=trim($value);
+            }
+        }
 	}
 }
-
+// Process the fallback file (language 00)
 $a=$path."/lang/00/$msg_tab";
 if (file_exists($a)) {
 	$fp=file($a);
 	foreach($fp as $var=>$value){
 		if (trim($value)!="") {
-			if ($charset=="UTF-8" and strpos($_SESSION["lang"],"_utf8")===false)
-				$value=utf8_encode($value);			$value=str_replace('"','&#34;',$value);
-			$value=str_replace("'",'&#39;',$value);
 			$m=explode('=',$value,2);
-			$m[0]=trim($m[0]);
-			if (!isset($msgstr[$m[0]])) $msgstr[$m[0]]=trim($m[1]);
+			$key=trim($m[0]);
+            if (!isset($msgstr[$key]) and isset($m[1]) and trim($m[1]!="")) {
+                $value=$m[1];
+                $value=str_replace('"','&quot;',$value);
+                $value=str_replace("'",'&apos;',$value);
+                if ($charset=="UTF-8") {
+                    if (!mb_check_encoding($value,'UTF-8')) {
+                        $value=mb_convert_encoding($value,'UTF-8','ISO-8859-1');
+                    }
+                }
+                $msgstr[$key]=trim($value);
+            }
 		}
 	}
 }


### PR DESCRIPTION
Goal of this commit is improved facilitation of mixed ISO/UTF-8 operation.
The functional goal: read a message file into an assocative array is not touched.
3 supported combinations:
- ISO database with ISO language files. (no problem)
- UTF-8 database with UTF-8 language files (no problem)
- UTF-8 database with ISO language files (converts encoding, safe)
read_msg.php is updated to support these combinations without recoding if new set of message files is added.
Note: This code converts encoding. No language translations!