### PR TITLE
Update fmt.php to repair MARC leader storage

### DIFF
--- a/www/htdocs/central/dataentry/fmt.php
+++ b/www/htdocs/central/dataentry/fmt.php
@@ -3,6 +3,7 @@
 2021-03-20 guilda Error when searching due to quoting
 2021-04-23 fho4abcd Line endings,body tag
 2021-06-10 fho4abcd Remove password argument
+2021-07-07 fho4abcd Improve leader reformat (was broken since update to OPAC)
 */
 /**
  * @program:   ABCD - ABCD-Central - http://reddes.bvsaude.org/projects/abcd
@@ -571,8 +572,11 @@ if (file_exists($db_path.$arrHttp["base"]."/def/".$lang_db."/typeofrecord.tab"))
 foreach ($arrHttp as $var => $value) {
 	if (substr($var,0,3)=="tag" ){
 		$tag=explode("_",$var);
-		if (count($tag)>1){
-			if (isset($lid) and (substr($tag[0],3)>=$lid[0] and substr($tag[0],3)<=$lid[1] or (count($tmLeader)>0 and (substr($tag[0],3)==$tmLeader[0] or substr($tag[0],3)==$tmLeader[1])))){  //IF LEADER, REFORMAT THE FIELD FOR ELIMINATING |
+		if (count($tag)>0){ //IF LEADER, REFORMAT THE FIELD FOR ELIMINATING |
+			if ( isset($lid) and substr($tag[0],3)>=$lid[0] and substr($tag[0],3)<=$lid[1]  or
+                 count($tmLeader)>0 and
+                    (substr($tag[0],3)==$tmLeader[0] or substr($tag[0],3)==$tmLeader[1])
+                ) {  
 				$v=explode('|',$value);
 				$value=$v[0];
 			}


### PR DESCRIPTION
Improve MARC leader reformat (was broken since update to OPAC). The leader info is now stored correct and shown as intended.