### PR TITLE
Update ldap.php

### DIFF
--- a/www/htdocs/central/common/ldap.php
+++ b/www/htdocs/central/common/ldap.php
@@ -21,7 +21,7 @@ function isLdapUser($username,$password, $ldap){
         return false;
 }
 
-function Auth($username, $password, $adGroupName = false){
+function Auth($username, $password, string $adGroupName = 'false'){
     global $ldap_host,$ldap_dn,$ldap_port;
 
     $ldap = ldap_connect($ldap_host,$ldap_port);
@@ -32,8 +32,8 @@ function Auth($username, $password, $adGroupName = false){
      return isLdapUser($username, $password, $ldap);
 }
 
-function Info($username, $password, $adGroupName = false,$attrib){
-    global $ldap_host,$ldap_dn,$ldap_port,$ldap_pass,$ldap_search_context;;
+function Info($username, $password, $attrib, string $adGroupName = 'false'){
+    global $ldap_host,$ldap_dn,$ldap_port,$ldap_pass,$ldap_search_context;
 
     $ldap = ldap_connect($ldap_host,$ldap_port);
 


### PR DESCRIPTION
This file was showing on my server the message:

Deprecated: Required parameter $attrib follows optional parameter $adGroupName in \ABCD2\www\htdocs\central\common\ldap.php on line 35

Changed from:
function info($username, $password, $adGroupName = false, $attrib)

To:
function info($username, $password, $attrib, string $adGroupName = 'false')