### PR TITLE
Adjustment for the select to point to the default language.

### DIFF
--- a/www/htdocs/index.php
+++ b/www/htdocs/index.php
@@ -14,6 +14,7 @@ include("$app_path/common/get_post.php");
 $new_window=time();
 //foreach ($arrHttp as $var=>$value) echo "$var = $value<br>";
 $lang_config=$lang;
+
 $lang = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
 
 if (isset($_SESSION["lang"])){
@@ -192,7 +193,7 @@ if (isset($arrHttp["login"]) and $arrHttp["login"]=="N"){
 			if ($value!=""){
 				$l=explode('=',$value);
 				if ($l[0]!="lang"){
-					if ($l[0]==$_SESSION["lang"]) $selected=" selected";
+					if ($l[0]==$lang) $selected=" selected";
 					echo "<option value=$l[0] $selected>".$msgstr[$l[0]]."</option>\n";
 					$selected="";
 				}


### PR DESCRIPTION
I remember that in some version of ABCD there was a function that set English as default in the absence of the directory of some language, so I added the option without realizing that this function did not exist.

About the adopted solution, I don't know if it is safe to put the server path in the index. In demo installations it will show the server path publicly.

![](https://user-images.githubusercontent.com/20482054/132931840-7c4d666b-fb4c-41d1-ac1d-072cff3e509f.png)