### PR TITLE
Improve error message & handling for uploading files

### DIFF
--- a/www/htdocs/central/lang/00/soporte.tab
+++ b/www/htdocs/central/lang/00/soporte.tab
@@ -183,6 +183,9 @@ transferido=Uploaded
 useslashm=Use /m parameter
 unch_append=Unchecked = Append records
 unch_wxis=Unchecked = Use WXIS
+upload_conf_errmsg=May be a configuration error for file uploads. Check log files and php.ini.
+upload_logout=Logout recommended
+upload_exceed=Exceeded
 warnforslashm=Warning: do not check this parameter if you<br>are using picklists with type DB in the FDT
 warnmuchoutput=Warning: levels 2,3 give much feedback
 workfolder=Work folder

--- a/www/htdocs/central/utilities/docfiles_upload.php
+++ b/www/htdocs/central/utilities/docfiles_upload.php
@@ -1,6 +1,7 @@
 <?php
 /* Modifications
 20210807 fho4abcd Created from upload_myfile.php
+20210914 fho4abcd Improved error message display&handling in case of upload errors
 */
 /*
 ** Upload a file from the users environment into the digital document area of ABCD
@@ -42,6 +43,7 @@ $upldoc_cnfcnt=0;
 if ( isset($arrHttp["backtoscript"]))  $backtoscript=$arrHttp["backtoscript"];
 if ( isset($arrHttp["inframe"]))       $inframe=$arrHttp["inframe"];
 if ( isset($arrHttp["upldoc_cnfcnt"])) $upldoc_cnfcnt=$arrHttp["upldoc_cnfcnt"];
+if ( !isset($arrHttp["base"])) $arrHttp["base"]=""; // In case of upload errors destroying this option
 $backtourl=$backtoscript."?base=".$arrHttp["base"]."&inframe=".$inframe;
 ?>
 <body>
@@ -71,21 +73,11 @@ function DocfilesImport(){
 </script>
 <?php
 // If outside a frame: show institutional info
-if ($inframe!=1) include "../common/institutional_info.php";
+if ($inframe!=1 or $arrHttp["base"]=="") include "../common/institutional_info.php";
 ?>
 <div class="sectionInfo">
 	<div class="breadcrumb">
-<?php   echo $msgstr["mantenimiento"].": ".$msgstr["dd_upload"];
-        if ($contents_error!="") {
-            echo "<br><b style='color:red'>".$msgstr["fatal"].": &rarr; </b>".$contents_error["message"];
-            echo "<br>May be a configuration error for file uploads. ";
-            echo "Check log files and php.ini ";
-            echo "<br>-- Exceeded 'post_max_size' (= ".ini_get('post_max_size')." ) ?";
-            echo "<br>-- Exceeded 'upload_max_filesize' (= ".ini_get('upload_max_filesize')." ) ?";
-            echo "<br>-- Exceeded 'max_file_uploads' (= ".ini_get('max_file_uploads')." ) ?";
-            die;
-        }
-?>
+    <?php echo $msgstr["mantenimiento"].": ".$msgstr["dd_upload"];?>
 	</div>
 	<div class="actions">
 <?php
@@ -103,11 +95,24 @@ include "../common/inc_div-helper.php";
 <div class="formContent">
     <img  src="../dataentry/img/preloader.gif" alt="Loading..." id="preloader"
           style="visibility:hidden;position:absolute;top:30%;left:45%;border:2px solid;"/>
+    <?php
+    if ($contents_error!="") {
+        echo "<br><b style='color:red'>".$msgstr["fatal"].": &rarr; </b>".$contents_error["message"];
+        echo "<br>".$msgstr["upload_conf_errmsg"];
+        echo "<br>-- ".$msgstr["upload_exceed"]." 'post_max_size' (= ".ini_get('post_max_size').") ?";
+        echo "<br>-- ".$msgstr["upload_exceed"]." 'upload_max_filesize' (= ".ini_get('upload_max_filesize').") ?";
+        echo "<br>-- ".$msgstr["upload_exceed"]." 'max_file_uploads' (= ".ini_get('max_file_uploads').") ?";
+        echo "<br><br><b style='color:red'>".$msgstr["upload_logout"]."</b>";
+        echo "</div></div>";
+        die;
+    }
+    ?>
     <div align=center><h3><?php echo $msgstr["dd_upload"] ?></h3>
 
 <?php
 // Set collection related parameters and create folders if not present
 include "../utilities/inc_coll_chk_init.php";
+
 
 /* ----- First screen: Select the doc file -*/
 if ($upldoc_cnfcnt<=0) {

--- a/www/htdocs/central/utilities/upload_wrkfile.php
+++ b/www/htdocs/central/utilities/upload_wrkfile.php
@@ -1,6 +1,7 @@
 <?php
 /* Modifications
 20210516 fho4abcd Created from upload_myfile.php
+20210914 fho4abcd Improved error message display&handling in case of upload errors
 */
 /*
 ** Upload a file from the users environment into the working area of the ABCD base
@@ -32,6 +33,8 @@ $uplwrk_cnfcnt=0;
 if ( isset($arrHttp["backtoscript"])) $backtoscript=$arrHttp["backtoscript"];
 if ( isset($arrHttp["inframe"]))      $inframe=$arrHttp["inframe"];
 if ( isset($arrHttp["uplwrk_cnfcnt"])) $uplwrk_cnfcnt=$arrHttp["uplwrk_cnfcnt"];
+if ( !isset($arrHttp["base"])) $arrHttp["base"]=""; // In case of upload errors destroying this option
+
 $wrk="wrk";
 $wrkfull=$db_path.$wrk;
 $OK=" &rarr; OK";
@@ -62,21 +65,11 @@ function Continue(){
 </script>
 <?php
 // If outside a frame: show institutional info
-if ($inframe!=1) include "../common/institutional_info.php";
+if ($inframe!=1 or $arrHttp["base"]=="") include "../common/institutional_info.php";
 ?>
 <div class="sectionInfo">
 	<div class="breadcrumb">
-<?php   echo $msgstr["mantenimiento"].": ".$msgstr["uploadfile"];
-        if ($contents_error!="") {
-            echo "<br><b><font color=red>".$msgstr["fatal"].": &rarr; </font></b>".$contents_error["message"];
-            echo "<br>May be a configuration error for file uploads. ";
-            echo "Check log files and php.ini ";
-            echo "<br>-- Exceeded 'post_max_size' (= ".ini_get('post_max_size')." ) ?";
-            echo "<br>-- Exceeded 'upload_max_filesize' (= ".ini_get('upload_max_filesize')." ) ?";
-            echo "<br>-- Exceeded 'max_file_uploads' (= ".ini_get('max_file_uploads')." ) ?";
-            die;
-        }
-?>
+    <?php echo $msgstr["mantenimiento"].": ".$msgstr["uploadfile"];?>
 	</div>
 	<div class="actions">
 <?php
@@ -94,6 +87,18 @@ include "../common/inc_div-helper.php";
 <div class="formContent">
     <img  src="../dataentry/img/preloader.gif" alt="Loading..." id="preloader"
           style="visibility:hidden;position:absolute;top:30%;left:45%;border:2px solid;"/>
+    <?php
+    if ($contents_error!="") {
+        echo "<br><b style='color:red'>".$msgstr["fatal"].": &rarr; </b>".$contents_error["message"];
+        echo "<br>".$msgstr["upload_conf_errmsg"];
+        echo "<br>-- ".$msgstr["upload_exceed"]." 'post_max_size' (= ".ini_get('post_max_size').") ?";
+        echo "<br>-- ".$msgstr["upload_exceed"]." 'upload_max_filesize' (= ".ini_get('upload_max_filesize').") ?";
+        echo "<br>-- ".$msgstr["upload_exceed"]." 'max_file_uploads' (= ".ini_get('max_file_uploads').") ?";
+        echo "<br><br><b style='color:red'>".$msgstr["upload_logout"]."</b>";
+        echo "</div></div>";
+        die;
+    }
+    ?>
     <div align=center><h3><?php echo $msgstr["uploadfile"] ?></h3>
 
 <?php


### PR DESCRIPTION
The Upload errors were correctly detected but the message was not completely readable on linux and the code did not react properly on sideeffects of these errors (missing url variables).
This commit improves:
- Error messages are now completly visible on Linux&Windows
- Missing URL variables are handled sufficiently
- Recommend to logout: the header with logout is explicitly shown
- Error message strings can be translated