### PR TITLE
Enhance document import

### DIFF
--- a/www/htdocs/central/lang/00/importdoc.tab
+++ b/www/htdocs/central/lang/00/importdoc.tab
@@ -19,7 +19,7 @@ dd_error_init_cnfile=Cannot create initial file for the control number (CN)
 dd_error_next_cnfile=Cannot create file for the computed control number (CN)
 dd_movingfiles=Moving files to
 dd_filesmoved=file(s) moved.
-dd_granularity=Granularity
+dd_htmlfilesize=Size of generated HTML file=
 dd_imp_actfile=Working on
 dd_imp_details=Show details
 dd_imp_exec=Import
@@ -33,6 +33,7 @@ dd_imp_nofiles=NO files found in collection upload area:
 dd_imp_numfiles=files found in collection upload area:
 dd_imp_options=Import options
 dd_imp_proctime=Processing time
+dd_imp_numrec=Succesfully created records
 dd_imp_step=Step
 dd_imp_step_check_files=Check files to be imported.
 dd_imp_step_check_map=Check/set metadata mapping to ABCD fields
@@ -53,7 +54,9 @@ dd_notok=NOT OK
 dd_nowrite=is not writable
 dd_optionmsg=When in doubt: leave the defaults
 dd_overwrite=Overwrite existing file?
+dd_partnr=Part #
 dd_record_created=ABCD record created for
+dd_recordsize=Maximum DB recordsize=
 dd_rep_content=Repair content of field
 dd_rep_execresults=Repair execution results
 dd_rep_options=Select repair option
@@ -62,6 +65,7 @@ dd_section=Section
 dd_sectionhlp=Type section name or click twice to view existing section names
 dd_sectionfoldererr=Unable to create Section folder
 dd_size=Size
+dd_splitting=Split the file. Target size=
 dd_status=Status
 dd_term_contributor=Contributor
 dd_term_coverage=Coverage

--- a/www/htdocs/central/utilities/vmx_fullinv.php
+++ b/www/htdocs/central/utilities/vmx_fullinv.php
@@ -9,6 +9,7 @@
 20210409 fho4abcd Read actab,uctab,stw from .par file (no fixed files, equal to incremental update procedure)
 20210409          The stw file comes from tag STW (present in many .par files).
 20210527 fho4abcd Check existence and permissions uctab&actab. Translations
+20210923 fho4abcd option to specify fstfile by URL
 */
 /**
  * @program:   ABCD - ABCD-Central
@@ -55,8 +56,10 @@ include("../lang/dbadmin.php");
 */
 $backtoscript="../dataentry/administrar.php"; // The default return script
 $inframe=1;                      // The default runs in a frame
+$presetfstfile="";               // No default fst file
 if ( isset($arrHttp["backtoscript"])) $backtoscript=$arrHttp["backtoscript"];
 if ( isset($arrHttp["inframe"]))      $inframe=$arrHttp["inframe"];
+if ( isset($arrHttp["fstfile"]))      $presetfstfile=$arrHttp["fstfile"];
 ?>
 <body onunload=win.close()>
 <script src=../dataentry/js/lr_trim.js></script>
@@ -136,7 +139,11 @@ if(!isset($fst)) { // The form sets the fst: the first action of this php
     $handle=opendir($bd."/data/");
     while ($file = readdir($handle)) {
         if ($file != "." && $file != ".." && (strpos($file,".fst")||strpos($file,".FST"))) {
-            echo "<option value='$file'>$file</option>";
+            if ( $file==$presetfstfile) {
+                echo "<option selected value='$file'>$file</option>";
+            } else {
+                echo "<option value='$file'>$file</option>";
+            }
         }
     }
     echo "</select>"
@@ -270,5 +277,4 @@ if(!isset($fst)) { // The form sets the fst: the first action of this php
 
 <?php
 include("../common/footer.php");
-?>
-</body></html>
+


### PR DESCRIPTION
The rewritten document import was not aware of the database recordsize and missed the capability to split large files into smaller chunks. This the main enhancement of this commit.
Detailed enhancements of file docfiles_import.php:
- Checks the recordsize of the current database. If that limit is exceeded the file generated by tika is divided into suitable sizes and for each of these chunks a database record is created. The main metadata for these records is equal (reflecting the metadata of the source file).
- Each chunk file has a green partnumber block at its begin + a title so the tabs can be distinguished.
- Tika generates slightly different output for windows/linux. Chunk data is improved for both (remove duplicate spacing, remove huge metadata header, correct invalid html). Note: if the file is not split this correction is not (yet) executed
- Removing rubbish improved: the .proc file is deleted after processing
- The timestamp added to files is no longer in seconds but shows a more readable data/time
- The 'Delete' button image is changed to the new look
- The filesize of the html (chunk) files is stored in the generated record
- The last action button sends now the name of the fst to the inverted file generation
- The  unimplemented "granularity" option is removed from the menus

Detailed enhancements of vmx_fullinv.php:
- Accept the name of the preferred fst in the URL.