### PR TITLE
error 500 when connecting

### DIFF
--- a/www/htdocs/central/common/wxis_llamar.php
+++ b/www/htdocs/central/common/wxis_llamar.php
@@ -147,7 +147,7 @@ if ($cset=="UTF-8" and strtoupper($unicode)=="ANSI"){
     if (isset($cont_cnv))$contenido=$cont_cnv;
 }
 // Write a line for this action to the log file
-if (is_dir($db_path."log") ){
+if (is_writable($db_path."log") && is_dir($db_path."log")){
     $fp=fopen($db_path."log/log_".date("Ymd").".log","a");
     $out=date('Ymd h:i:s')."\t";
     if( isset($_SESSION['login'])) {


### PR DESCRIPTION
This script gives error 500 when connecting to Linux with PHP 8.  
Reason: it wasn't verifying the write permissions.

I put this verification, but I didn't include any message informing the user that the log is not being saved. I didn't find the best way to do it.