### PR TITLE
Minor adjustments in the validation of records

### DIFF
--- a/www/htdocs/assets/css/styles.css
+++ b/www/htdocs/assets/css/styles.css
@@ -280,11 +280,16 @@ a.menuButton span {
 	border-radius: 4px;
 }
 
+table.alert:before {
+	display: none;
+}
+
 .alert:before {
 	font-family: "Font Awesome 5 Free";
 	content: "\f071";
 	color: #664d03;
 	margin-right: 10px;
+	display: inline-block;
 }
 
 
@@ -1695,7 +1700,7 @@ table.toolbarTable, table.toolbar-edit-dataentry {
 	padding: 4px 6px;
 /*	background: var(--white);*/
 /*  display: table-cell;*/
-	display: inline;
+	display: inline-table;
   vertical-align: middle;
 
 }

--- a/www/htdocs/central/dataentry/actualizarregistro.php
+++ b/www/htdocs/central/dataentry/actualizarregistro.php
@@ -1,4 +1,9 @@
 <?php
+/*
+20211119 rogercgui settings from "if (isset($output) and trim($output)!="")
+*/
+
+
 include("verificar_eliminacion.php");
 
 function ValidarDuplicados($tag,$subc,$prefijo,$valor,$titulo){
@@ -7,7 +12,8 @@ global $arrHttp,$db_path,$Wxis,$xWxis,$wxisUrl,$fdt,$msgstr,$def;
 	$occ=explode("\n",$valor);
 	$Expresion="";
 	$error="";
-	foreach ($occ as $value){		$value=trim($value);
+	foreach ($occ as $value){
+		$value=trim($value);
 		if (isset($subc)and $subc!=""){
 			$ix=strpos($value,"^".$subc);
 			$c=substr($value,$ix+2);
@@ -15,12 +21,18 @@ global $arrHttp,$db_path,$Wxis,$xWxis,$wxisUrl,$fdt,$msgstr,$def;
 			if ($ix>0){
 				$c=substr($c,0,$ix);
 			}
-		}else{			$c=$value;		}
-		if (trim($c)!=""){			if ($Expresion=="")
+		}else{
+			$c=$value;
+		}
+		if (trim($c)!=""){
+			if ($Expresion=="")
 				$Expresion=$prefijo.$c;
 			else
-				$Expresion.=" or ".$prefijo.$c;		}
-		if (isset($c_ant[$c])){			$error.="$tag $titulo $c ".$msgstr["dup_in_field"]."<br>";		}else{
+				$Expresion.=" or ".$prefijo.$c;
+		}
+		if (isset($c_ant[$c])){
+			$error.="$tag $titulo $c ".$msgstr["dup_in_field"]."<br>";
+		}else{
 		  	$c_ant[$c]=$c;
 		}
 	}
@@ -33,15 +45,21 @@ global $arrHttp,$db_path,$Wxis,$xWxis,$wxisUrl,$fdt,$msgstr,$def;
 	include("../common/wxis_llamar.php");
 
 	foreach ($contenido as $value) {
-		$value=trim($value);		if (substr($value,0,6)!="[MFN:]" and substr($value,0,8)!="[TOTAL:]" and $value!=""){
+		$value=trim($value);
+		if (substr($value,0,6)!="[MFN:]" and substr($value,0,8)!="[TOTAL:]" and $value!=""){
 			if (trim($value)!=""){
 				$i=explode('|',$value);
-				if ($arrHttp["Mfn"]=="New"){					if (isset($c_ant[$i[1]])) $error.="$tag $titulo ".$i[1]." ".$msgstr["duplicated"]." (Mfn:".$i[0].")<br>";				}else{					if ($i[0]*1!=$arrHttp["Mfn"])
+				if ($arrHttp["Mfn"]=="New"){
+					if (isset($c_ant[$i[1]])) $error.="$tag $titulo ".$i[1]." ".$msgstr["duplicated"]." (Mfn:".$i[0].")<br>";
+				}else{
+					if ($i[0]*1!=$arrHttp["Mfn"])
 						if (isset($c_ant[$i[1]])) $error.="$tag $titulo ".$i[1]." ".$msgstr["duplicated"]." (Mfn:".$i[0].")<br>";
                 }
 			}
 		}
-	}    return $error;}
+	}
+    return $error;
+}
 
 function CodificaSubCampos($campo,$numsubc,$subc,$delimsc){
 $valores=explode("\n",$campo);
@@ -79,16 +97,23 @@ global $max_cn_length,$def;
 	$variables_org=$variables;
 	$ValorCapturado="";
 	$VC="";
-	if ($arrHttp["Opcion"]=="eliminar"){		$archivo=$db_path.$arrHttp["base"]."/pfts/recdel_val";
+	if ($arrHttp["Opcion"]=="eliminar"){
+		$archivo=$db_path.$arrHttp["base"]."/pfts/recdel_val";
 		$verify="";
-		if (file_exists($archivo.".pft")){			$verify="Y";
-		}else{            $archivo=$db_path.$arrHttp["base"]."/pfts/".$_SESSION["lang"]."/recdel_val";
+		if (file_exists($archivo.".pft")){
+			$verify="Y";
+		}else{
+            $archivo=$db_path.$arrHttp["base"]."/pfts/".$_SESSION["lang"]."/recdel_val";
             if (file_exists($archivo.".pft")){
 				$verify="Y";
-			}else{				$archivo=$db_path.$arrHttp["base"]."/pfts/".$lang_db."/recdel_val";
+			}else{
+				$archivo=$db_path.$arrHttp["base"]."/pfts/".$lang_db."/recdel_val";
             	if (file_exists($archivo.".pft")){
 					$verify="Y";
-				}			}		}		if ($verify=="Y") {
+				}
+			}
+		}
+		if ($verify=="Y") {
 			$salida=VerificarEliminacion($archivo);
 			if ($salida!=""){
 				echo "<div class=\"middle form\">
@@ -144,8 +169,11 @@ global $max_cn_length,$def;
 			$numsubc=strlen($subc);
  			$delimsc=$t[6];
  			$ispassword=$t[7];
- 			if ($ispassword=="P" and isset($MD5) and $MD5==1 ){ 				$variables["tag".$tag]= md5($variables["tag".$tag]);
- 			}else{ 			}
+ 			if ($ispassword=="P" and isset($MD5) and $MD5==1 ){
+ 				$variables["tag".$tag]= md5($variables["tag".$tag]);
+ 			}else{
+
+ 			}
 			if ($subc!="" && $tipoc!="T"){
 				$lin=trim($variables["tag".$tag]);
                 if (!isset($default_values) and !isset($rec_validation) and !isset($end_code)){
@@ -159,12 +187,15 @@ global $max_cn_length,$def;
 			}
 // si $rep=T el campo se edita en forma de tabla por lo que hay que convertirlo en un campo
 // repetible con subcampos
-		//	if ($rep=="T") {			$dummy=explode("\n",$variables["tag".$tag]);
+		//	if ($rep=="T") {
+			$dummy=explode("\n",$variables["tag".$tag]);
 			$salida="";
 			foreach ($dummy as $linea) {
  				//$linea=trim($linea);  //no colocar el trim porque borra los espacios antes del indicador
- 				if (trim($linea!="")){					$xlin="";
-					for ($i=0; $i<strlen($subc);$i++){						$resc="";
+ 				if (trim($linea!="")){
+					$xlin="";
+					for ($i=0; $i<strlen($subc);$i++){
+						$resc="";
 						if ($i==0 and (substr($subc,$i,1)=="_" or substr($subc,$i,1)=="-")){
                                 if (substr($linea,0,1)=="^")
                                 	$linea=substr($linea,1);
@@ -184,9 +215,12 @@ global $max_cn_length,$def;
 								$ix1=$ix1+strlen($resc);
 								$valorsc=substr($linea,$ix1,$ix2-$ix1);
 								if (trim($valorsc)!="") {
-									if ($i==0){										if ($resc=="^" ) {
+
+									if ($i==0){
+										if ($resc=="^" ) {
 											$resc="";
-										}									}
+										}
+									}
 									$xlin.=$resc.$valorsc;
 								}
 								$linea=substr($linea,$ix2);
@@ -197,13 +231,18 @@ global $max_cn_length,$def;
       			}
 			}
 			if (trim($salida)!="") $variables["tag".$tag]= $salida;
-		}else{			if ($dataentry!="B") $variables["tag".$tag]="";       //THE EXTERNAL HTML IS NOT UPDATED		}
+		}else{
+			if ($dataentry!="B") $variables["tag".$tag]="";       //THE EXTERNAL HTML IS NOT UPDATED
+		}
 	}
 	$val_duplicado="";
 
     if (isset($arrHttp["check_select"])){
     	$dummy=array();
-    	$dummy=explode("\n",$arrHttp["check_select"]);    	foreach ($dummy as $value){    		if (trim($value)!=""){	    		$ixD=strpos($value,"_");
+    	$dummy=explode("\n",$arrHttp["check_select"]);
+    	foreach ($dummy as $value){
+    		if (trim($value)!=""){
+	    		$ixD=strpos($value,"_");
 	    		if ($ixD>0){
 		    		$parte1=substr($value,0,$ixD);
 		    		$parte2=substr($value,$ixD+1);
@@ -222,11 +261,13 @@ global $max_cn_length,$def;
 				    	$VC.=$k." ".$parte2."\n";
 					}
 				}
-             }    	}
+             }
+    	}
 	}
 
 	if ($arrHttp["Opcion"]!="eliminar" and isset($variables)){
-		foreach ($variables as $key => $lin){
+
+		foreach ($variables as $key => $lin){
 		//OJO No se deben eliminar las líneas cuyo contenido esté vacío porque ello significa
 		// que se quiere eliminar el campo   del registro
 			$key=trim(substr($key,3));
@@ -259,7 +300,8 @@ global $max_cn_length,$def;
  	$Eli_array=array();
  	foreach ($valc as $v){
  		//$v=trim($v);
- 		if (trim(substr($v,0,4))!=""){ 			if (!isset($Eli_array[substr($v,0,4)])){
+ 		if (trim(substr($v,0,4))!=""){
+ 			if (!isset($Eli_array[substr($v,0,4)])){
  		   		$Eliminar.="d".substr($v,0,4);
  		   		$Eli_array[substr($v,0,4)]="S";
  			}
@@ -283,34 +325,55 @@ global $max_cn_length,$def;
 
 	   		// si en la FDT existe un campo del tipo autoincrement, entonces se determina el número de identificación
 	   		// si el valor del campo ya viene fijado entonces no se genera un nuevo valor
-	   		if(isset($arrHttp["autoincrement"]) and $arrHttp["Mfn"]=="New"){	 			if (isset($arrHttp["tag".$arrHttp["autoincrement"]]) and $arrHttp["tag".$arrHttp["autoincrement"]]=="" or !isset($arrHttp["tag".$arrHttp["autoincrement"]])){	 				$nc="";	 			 	include("autoincrement.php");
-	 			 	if ($cn=="" or $cn==false){                        $fatal_cn="Could not generate the control number";	 			 	}else{
+	   		if(isset($arrHttp["autoincrement"]) and $arrHttp["Mfn"]=="New"){
+	 			if (isset($arrHttp["tag".$arrHttp["autoincrement"]]) and $arrHttp["tag".$arrHttp["autoincrement"]]=="" or !isset($arrHttp["tag".$arrHttp["autoincrement"]])){
+	 				$nc="";
+	 			 	include("autoincrement.php");
+	 			 	if ($cn=="" or $cn==false){
+                        $fatal_cn="Could not generate the control number";
+	 			 	}else{
 		   				$key=$arrHttp["autoincrement"];
 						$ValorCapturado.="<".$key." 0>".$cn."</".$key.">";
 						$VC.=$arrHttp["autoincrement"]." ".$cn."\n";
 					}
-				}else{					$cn=$arrHttp["tag".$arrHttp["autoincrement"]];				}
-	   		}
+				}else{
+					$cn=$arrHttp["tag".$arrHttp["autoincrement"]];
+				}
+
+	   		}
 
 	        unset($validar);
 			$pftval="";
-			if (isset($arrHttp["wks"])){				$val=explode(".",$arrHttp["wks"]);
-				if (file_exists($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/".$val[0].".val")){					$pftval=$val[0].".val";
+			if (isset($arrHttp["wks"])){
+				$val=explode(".",$arrHttp["wks"]);
+				if (file_exists($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/".$val[0].".val")){
+					$pftval=$val[0].".val";
 				}else{
-					if (isset($tm)){						foreach ($tm as $value){							$t=explode('|',$value);
-							if ($t[0]==$arrHttp["wks"]){								$tl=strtolower($t[1]);
+					if (isset($tm)){
+						foreach ($tm as $value){
+							$t=explode('|',$value);
+							if ($t[0]==$arrHttp["wks"]){
+								$tl=strtolower($t[1]);
 								$nr=strtolower($t[2]);
 								$pftval=$tl;
 								if (isset($nr) and $nr!="")
 									$pftval.="_".$nr;
 								$pftval.="_".$arrHttp["base"].".val";
-								break;							}						}					}
-				}			}
+								break;
+							}
+						}
+					}
+				}
+			}
 			$file_val="";
 			if ($pftval!=""){
-				$file_val=$db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/".$pftval;				if (!file_exists($file_val))  $file_val=$db_path.$arrHttp["base"]."/def/".$lang_db."/".$pftval;	        }
-			if ($file_val=="" or !file_exists($file_val)){				$file_val=$db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/".$arrHttp["base"].".val";
-				if (!file_exists($file_val))  $file_val=$db_path.$arrHttp["base"]."/def/".$lang_db."/".$arrHttp["base"].".val";			}
+				$file_val=$db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/".$pftval;
+				if (!file_exists($file_val))  $file_val=$db_path.$arrHttp["base"]."/def/".$lang_db."/".$pftval;
+	        }
+			if ($file_val=="" or !file_exists($file_val)){
+				$file_val=$db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/".$arrHttp["base"].".val";
+				if (!file_exists($file_val))  $file_val=$db_path.$arrHttp["base"]."/def/".$lang_db."/".$arrHttp["base"].".val";
+			}
 		//CALL THE VALIDATION FORMAT
 			$output="";
 			if (file_exists($file_val) and $arrHttp["Opcion"]!="save" and !isset($arrHttp["Validar"])){
@@ -323,23 +386,31 @@ global $max_cn_length,$def;
 			foreach ($cdup as $key=>$var){
 				if (isset($variables["tag".$key])){
 					$res=ValidarDuplicados($key,$var["subc"],$var["prefix"],$variables["tag".$key],$var["name"]);
-					if ($res!=""){						$fatal_dup.="<br>".$res;
+					if ($res!=""){
+						$fatal_dup.="<br>".$res;
 					}
 				}
 			}
 		}
 
-	    if ($fatal=="Y" or $fatal_cn!="" or $fatal_dup!="") {			echo "<div class=\"middle form\">
-					<div class=\"formContent\">
-				";
-
-			echo "<p><font color=red><strong>".$msgstr["recnotupdated"]."</strong></font>";
+	    if ($fatal=="Y" or $fatal_cn!="" or $fatal_dup!="") {
+			echo '<div class="sectionInfo">';
+			echo '<div class="breadcrumb">';
+			echo $msgstr['rval'];
+			echo '</div>';
+			echo '<div class="actions">';
+			echo '</div>';
+			echo '<div class="spacer">&#160;</div>';
+			echo '</div>';
+			echo '<div class="helper">dataentry/recval_check.php</div>';
+			echo '<div class="middle form">';
+			echo '<div class="formContent">';
+			echo '<h1>'.$msgstr['rval']." - <small>".$file_val.'</small></h1>';
+			echo "<p><font color=red><strong>".$msgstr["recnotupdated"]."</strong></font></p>";
 			if ($fatal_cn!="") echo $fatal_cn. " $cn";
 			if ($fatal_dup!="") echo $fatal_dup;
 			$error= $output;
 			echo $output;
-		//	if (isset($arrHttp["autoincrement"]))
-	  	//		echo "<p><font color=red><strong>".$msgstr["cwritefile"]. "control_number.cn"."</strong></font>";
 	  	    $VC=urlencode($VC);
 			$url= "fmt.php?base=".$arrHttp["base"]."&cipar=".$arrHttp["base"].".par&ValorCapturado=$VC&Opcion=reintentar&Mfn=".$arrHttp["Mfn"]."&error=".urlencode($error)."&Formato=".$arrHttp["Formato"];
 			if (isset($arrHttp["wks_a"])) $url.="&wks=".$arrHttp["wks_a"];
@@ -347,45 +418,67 @@ global $max_cn_length,$def;
 			$url.="&ver=N";
 			if (isset($arrHttp["db_copies"]))  $url.="&db_copies=".$arrHttp["db_copies"];
 			if (isset($arrHttp["ventana"])) $url.="&ventana=".$arrHttp["ventana"];
-			echo "<p><a href=$url><h3>".$msgstr["editar"]."</h3></a>";
+			echo "<br><a class='bt bt-blue' href=$url><i class='far fa-edit'></i> ".$msgstr["editar"]."</a>";
+			echo "</div></div>";
 			echo "</div></div>";
 			die;
-		}else{			if (isset($output) and trim($output)!=""){				echo $output;
-
-				$VC=urlencode($VC);
-				$url_orig= "fmt.php?base=".$arrHttp["base"]."&cipar=".$arrHttp["base"].".par&ValorCapturado=$VC&Mfn=".$arrHttp["Mfn"]."&error=".urlencode($error)."&Formato=".$arrHttp["Formato"];
-				$url=$url_orig."&Opcion=reintentar";
-				if (isset($arrHttp["wks_a"])) $url.="&wks=".$arrHttp["wks_a"];
-				$url.="&ver=N";
-				if (isset($arrHttp["db_copies"]))  $url.="&db_copies=".$arrHttp["db_copies"];
-				if (isset($arrHttp["ventana"])) $url.="&ventana=".$arrHttp["ventana"];
-				echo "<p><a href=$url><strong><font size=4>".$msgstr["editar"]."</font></a>";
-				echo "&nbsp; &nbsp;";
-				$url=$url_orig."&Opcion=cancelar";
-				if (isset($arrHttp["wks_a"])) $url.="&wks=".$arrHttp["wks_a"];
-				$url.="&ver=N";
-				if (isset($arrHttp["db_copies"]))  $url.="&db_copies=".$arrHttp["db_copies"];
-				if (isset($arrHttp["ventana"])) $url.="&ventana=".$arrHttp["ventana"];
-				echo "<a href=$url><font size=4>".$msgstr["cancelar"]."</font></a>";
-				echo "&nbsp; &nbsp;";
-				$url=$url_orig."&Opcion=save";
-				if (isset($arrHttp["wks_a"])) $url.="&wks=".$arrHttp["wks_a"];
-				$url.="&ver=N";
-				if (isset($arrHttp["db_copies"]))  $url.="&db_copies=".$arrHttp["db_copies"];
-				echo "<a href=$url><font size=4>".$msgstr["save"]."</font></a>";
-				echo "</div></div>";
-				die;			}		}
+		}else{
+			if (isset($output) and trim($output)!=""){
+			echo '<div class="sectionInfo">';
+			echo '<div class="breadcrumb">';
+			echo $msgstr['rval'];
+			echo '</div>';
+			echo '<div class="actions">';
+			echo '</div>';
+			echo '<div class="spacer">&#160;</div>';
+			echo '</div>';
+			echo '<div class="helper">dataentry/recval_check.php</div>';
+			echo '<div class="middle form">';
+			echo '<div class="formContent">';
+			echo '<h1>'.$msgstr['rval']." - <small>".$file_val.'</small></h1>';
+			echo $output;
+			$VC=urlencode($VC);
+			$url_orig= "fmt.php?base=".$arrHttp["base"]."&cipar=".$arrHttp["base"].".par&ValorCapturado=$VC&Mfn=".$arrHttp["Mfn"]."&error=".urlencode($error)."&Formato=".$arrHttp["Formato"];
+			$url=$url_orig."&Opcion=reintentar";
+			if (isset($arrHttp["wks_a"])) $url.="&wks=".$arrHttp["wks_a"];
+			$url.="&ver=N";
+			if (isset($arrHttp["db_copies"]))  $url.="&db_copies=".$arrHttp["db_copies"];
+			if (isset($arrHttp["ventana"])) $url.="&ventana=".$arrHttp["ventana"];
+			echo "<p><a class='bt bt-blue' href=$url><i class='far fa-edit'></i> ".$msgstr["editar"]."</a>";
+			echo "&nbsp; &nbsp;";
+			$url=$url_orig."&Opcion=cancelar";
+			if (isset($arrHttp["wks_a"])) $url.="&wks=".$arrHttp["wks_a"];
+			$url.="&ver=N";
+			if (isset($arrHttp["db_copies"]))  $url.="&db_copies=".$arrHttp["db_copies"];
+			if (isset($arrHttp["ventana"])) $url.="&ventana=".$arrHttp["ventana"];
+			echo "<a class='bt bt-gray' href=$url><i class='fas fa-times'></i> ".$msgstr["cancelar"]."</a>";
+			echo "&nbsp; &nbsp;";
+			$url=$url_orig."&Opcion=save";
+			if (isset($arrHttp["wks_a"])) $url.="&wks=".$arrHttp["wks_a"];
+			$url.="&ver=N";
+			if (isset($arrHttp["db_copies"]))  $url.="&db_copies=".$arrHttp["db_copies"];
+			echo "<a class='bt bt-green' href=$url><i class='far fa-save'></i> ".$msgstr["save"]."</a>";
+			echo "</div></div>";
+			echo '</div></div>';
+			die;
+			}
+		}
 	}else{
 		if ($arrHttp["Opcion"]=="save"){
-
 			//$ValorCapturado=urlencode($ValorCapturado);
 			//$VC=urlencode($VC);
 	        unset($validar);
 		}
 	}
-	if ($arrHttp["Opcion"]=="save") {		$arrHttp["Validar"]="NO";
-		$arrHttp["Opcion"]="actualizar";	}
- 	if ($arrHttp["Opcion"]=="addocc"){ 		$ValorCapturado=urlencode($ValorCapturado); 	}else{ 		$ValorCapturado=urlencode($Eliminar.$ValorCapturado); 	}
+	if ($arrHttp["Opcion"]=="save") {
+		$arrHttp["Validar"]="NO";
+		$arrHttp["Opcion"]="actualizar";
+	}
+ 	if ($arrHttp["Opcion"]=="addocc"){
+ 		$ValorCapturado=urlencode($ValorCapturado);
+ 	}else{
+ 		$ValorCapturado=urlencode($Eliminar.$ValorCapturado);
+ 	}
 	if ($arrHttp["Mfn"]=="New") $arrHttp["Opcion"]="crear";
 	$IsisScript=$xWxis."actualizar.xis";
 	if (file_exists($db_path."$base/data/stw.tab"))
@@ -398,12 +491,17 @@ global $max_cn_length,$def;
   	$query = "&base=".$base ."&cipar=$db_path"."par/".$cipar."&login=".$_SESSION["login"]."&Mfn=" . $arrHttp["Mfn"]."&Opcion=".$arrHttp["Opcion"]."$stw&ValorCapturado=".$ValorCapturado;
 
   	if (isset($arrHttp["wks"])) $query.="&wks=".$arrHttp["wks"];
-  	if (isset($arrHttp["Validar"])){  		$query.="&Validar=NO";  	}
+  	if (isset($arrHttp["Validar"])){
+  		$query.="&Validar=NO";
+  	}
 	include("../common/wxis_llamar.php");
 //	echo "Longitud del campo de actualización: ".strlen($ValorCapturado);
     $salida="";
 	foreach ($contenido as $linea){
-        if (substr($linea,0,4)=="WXIS"){        	echo $linea;        }		if (substr($linea,0,4)=="MFN:") {
+        if (substr($linea,0,4)=="WXIS"){
+        	echo $linea;
+        }
+		if (substr($linea,0,4)=="MFN:") {
 	    	$arrHttp["Mfn"]=trim(substr($linea,4));
 		}else{
 			if (trim($linea)!="") $salida.= $linea."\n";
@@ -418,6 +516,5 @@ if(isset($arrHttp["Opcion"]) and $arrHttp["Opcion"]=="crear"){
 	$maxmfn=$arrHttp["Mfn"];
 	$arrHttp["Maxmfn"]=$maxmfn;
 }
-
 
 ?>

--- a/www/htdocs/central/dataentry/recval_check.php
+++ b/www/htdocs/central/dataentry/recval_check.php
@@ -90,7 +90,7 @@ if (file_exists($file_val)){
 			if (trim($v_res)!=""){
 				$output.="<tr><td valign=top>$v_tag</td><td valign=top>".nl2br($v_res)."</td>";
 				if (isset($err[$ix_fatal])and $err[$ix_fatal]=="true"){
-					$output.=  "<td valign=top><font color=darkred>".$msgstr["fatal"]."</td>";
+					$output.=  "<td valign=top>&nbsp;<font color=darkred>".$msgstr["fatal"]."</td>";
 					$fatal="Y";
 				}else{
 					$output.=  "<td>&nbsp;</td>";
@@ -98,7 +98,9 @@ if (file_exists($file_val)){
 			}
 	    }
 	}
-	if (trim($output)!="") {		$output="<table bgcolor=#dddddd>".$output. "</table>";	}
+	if (trim($output)!="") {
+		$output="<table class='alert'><tr><td>".$output."<td></tr></table>";
+	}
 }else{
 	$output="";
 	$fatal="";


### PR DESCRIPTION
If any line is marked "Fatal check.

![](https://user-images.githubusercontent.com/20482054/142675267-db357ee4-bf99-4b40-b093-92e4911f1cf1.png)

We only get the edit option

![](https://user-images.githubusercontent.com/20482054/142675526-5e0310c0-6977-46e7-8fdf-4d753d1c60eb.png)

If "Fatal error" is unchecked

![](https://user-images.githubusercontent.com/20482054/142675940-24021eb3-c051-47d4-86ee-50d8cb4b23d7.png)

We get the cancel and save buttons even with the error message.

![](https://user-images.githubusercontent.com/20482054/142676160-bc93c270-a91f-4789-9bb9-213a901bcfc7.png)

The way the message appears is defined by a simple CISIS format language similar to a PFT.

Advice:

A simple code `if a(v100) then 'Field 100 has not been filled in' fi` is enough.