### PR TITLE
Visual improvement + standard backbutton

### DIFF
--- a/www/htdocs/central/common/inc_back.php
+++ b/www/htdocs/central/common/inc_back.php
@@ -1,0 +1,24 @@
+<?php
+/*
+20211214 fho4abcd Created
+Function  : Show the backbutton in the breadcrumb in div class actions
+Usage     : <?php include "../common/inc_back.php" ?>
+** Variables
+**  $arrHttp["base"]: The current database. If not set the Home page is shown
+**  $backtoscript   : The return script.  If not set the Home page is shown
+*/
+
+$inc_backtourl="";
+if (isset($backtoscript) AND $backtoscript!="" ) {
+    $inc_backtourl=$backtoscript;
+} else {
+    $inc_backtourl="/central/common/inicio.php";
+}
+if (isset($arrHttp["base"]) AND $arrHttp["base"]!="")  {
+    $inc_backtourl.="?base=".$arrHttp["base"];
+}
+?>
+<a href="<?php echo $inc_backtourl?>" class="button_browse " title='<?php echo $msgstr["regresar"]?>'>
+    <i class="fas fa-arrow-circle-left"></i>&nbsp;<?php echo $msgstr["regresar"]?></a>
+<?php
+unset($inc_backtourl);

--- a/www/htdocs/central/dbadmin/menu_bar.php
+++ b/www/htdocs/central/dbadmin/menu_bar.php
@@ -20,6 +20,7 @@
 20210903 fho4abcd Add options to configure Digital documents functionality and Repair Digital Documents
 20211029 edsz14 Replace vmx_fullinv.php by fullinv.php
 20211114 fho4abcd Add create_gizmo
+20211214 fho4abcd Digital documents to top menu
 */
 $lang=$_SESSION["lang"];
 unset($_SESSION["Browse_Expresion"]);
@@ -356,16 +357,16 @@ function EnviarFormaMNT(Opcion,Mensaje){
         <?php if ($arrHttp["base"]==("dcdspace")) { ?>
 		<li><a href='Javascript:EnviarFormaMNT("dcdspace","<?php echo $msgstr["dspace_title"]?>")'><?php echo $msgstr["dspace_title"]?></a></li>
         <?php } ?>
-  		<li><a href="#"><?php echo $msgstr["dd_documents"]?></a>
-    		<ul>
-				<li><a href='Javascript:EnviarFormaMNT("importdoc","<?php echo $msgstr["dd_upload"]?>")'><?php echo $msgstr["dd_upload"]?></a></li>
-    			<li><a href='Javascript:EnviarFormaMNT("docbatchimport","<?php echo $msgstr["dd_batchimport"]?>")'><?php echo $msgstr["dd_batchimport"]?></a></li>
-                <li><a href='#'>&nbsp;</a></li>
-				<li><a href='Javascript:EnviarFormaMNT("docfilesconfig","<?php echo $msgstr["dd_config"]?>")'><?php echo $msgstr["dd_config"]?></a></li>
-				<li><a href='Javascript:EnviarFormaMNT("docfilesrepair","<?php echo $msgstr["dd_repair"]?>")'><?php echo $msgstr["dd_repair"]?></a></li>
-			</ul>
-  		</li>
   	</ul>
+  </li>
+  <li><a href="#"><?php echo $msgstr["dd_documents"]?></a>
+    <ul>
+        <li><a href='Javascript:EnviarFormaMNT("importdoc","<?php echo $msgstr["dd_upload"]?>")'><?php echo $msgstr["dd_upload"]?></a></li>
+        <li><a href='Javascript:EnviarFormaMNT("docbatchimport","<?php echo $msgstr["dd_batchimport"]?>")'><?php echo $msgstr["dd_batchimport"]?></a></li>
+        <li><a href='#'>&nbsp;</a></li>
+        <li><a href='Javascript:EnviarFormaMNT("docfilesconfig","<?php echo $msgstr["dd_config"]?>")'><?php echo $msgstr["dd_config"]?></a></li>
+        <li><a href='Javascript:EnviarFormaMNT("docfilesrepair","<?php echo $msgstr["dd_repair"]?>")'><?php echo $msgstr["dd_repair"]?></a></li>
+    </ul>
   </li>
   <li><a href="#"><?php echo $msgstr["dbbackrest"]?></a>
    	<ul>

--- a/www/htdocs/central/dbadmin/menu_mantenimiento.php
+++ b/www/htdocs/central/dbadmin/menu_mantenimiento.php
@@ -6,6 +6,7 @@
 20210324 fho4abcd Catch error after database deletion, display also long name of the database
 20210415 fho4abcd use charset from config.php
 20210803 fho4abcd added language file
+20211214 fho4abcd Backbutton by included file
 */
 session_start();
 
@@ -59,27 +60,20 @@ foreach ($fp as $value){
 include("../common/header.php");
 ?>
 <body>
-
-
 <script language="JavaScript" type="text/javascript" src=../dataentry/js/lr_trim.js></script>
-
 <?php
-	include("../common/institutional_info.php");
-	$encabezado="&encabezado=s";
+include("../common/institutional_info.php");
+$encabezado="&encabezado=s";
 ?>
-
-
-	<div class="sectionInfo">
-			<div class="breadcrumb">
-				<?php echo $msgstr["maintenance"]. ": " . $arrHttp["base"]; ?>
-			</div>
-			<div class="actions">
-				<a href="../common/inicio.php?reinicio=s&base=<?php echo $arrHttp["base"]; ?>" class="defaultButton backButton">
-					<img src="../../assets/images/defaultButton_iconBorder.gif" />
-				<span><strong><?php echo $msgstr["back"]; ?></strong></span></a>
-			</div>
-		   <div class="spacer">&#160;</div> 
-	</div>
+<div class="sectionInfo">
+    <div class="breadcrumb">
+        <?php echo $msgstr["maintenance"]. ": " . $arrHttp["base"]; ?>
+    </div>
+    <div class="actions">
+    <?php include "../common/inc_back.php";?>
+    </div>
+   <div class="spacer">&#160;</div> 
+</div>
 
 <?php
 include "../common/inc_div-helper.php";
@@ -89,10 +83,7 @@ include("menu_bar.php");
 ?>
 
 <div class="middle form">
-
 	<div class="formContent" style="min-height:300px;">
-
-
 	<div class="log_base">
 	<?php
 	// Get info about the current database from the database(if there is a database)
@@ -148,17 +139,6 @@ include("menu_bar.php");
         iframe.style.height = folga + 'px';
 
     }
-
-
- //   	document.getElementById("ABCD_Frame").getElementsByClassName("heading")style.visibility = "hidden";;
-  //  	var hidesectionInfo = iframe.contentWindow.document.getElementsByClassName("sectionInfo")[0];
-   // 	var hidemiddle = iframe.contentWindow.document.getElementsByClassName("middle")[0];
-  //  	var hidefooter = iframe.contentWindow.document.getElementsByClassName("footer")[0];
-  //      hidehead.style.visibility = "hidden";
-  //      hidesectionInfo.style.visibility = "hidden";	
-//        hidemiddle.style.background = "#fff";	
- //       hidefooter.style.display = "none";	
-
     </script>
 
 	</div> <!--./formContent-->

--- a/www/htdocs/central/utilities/cnv_iso_2_utf.php
+++ b/www/htdocs/central/utilities/cnv_iso_2_utf.php
@@ -2,6 +2,7 @@
 /* Modifications
 20210607 fho4abcd Created new (from vmx_import_iso)
 20210609 fho4abcd Added explanation message+ bug in confirmcount
+20211214 fho4abcd Backbutton by included file
 */
 global $arrHttp;
 set_time_limit(0);
@@ -113,12 +114,7 @@ if ($inframe!=1) include "../common/institutional_info.php";
 ?>
 	</div>
 	<div class="actions">
-<?php
-        $backtourl=$backtoscript."?base=".$arrHttp["base"];
-        echo "<a href='$backtourl'  class=\"defaultButton backButton\">";
-?>
-		<img src="../../assets/images/defaultButton_iconBorder.gif" alt="" title="" />
-		<span><strong><?php echo $msgstr["regresar"]?></strong></span></a>
+    <?php include "../common/inc_back.php";?>
 	</div>
 	<div class="spacer">&#160;</div>
 </div>
@@ -291,5 +287,5 @@ if ($confirmcount==1) {  /* - Second screen: Present a menu with parameters -*/
 echo "</div></div></div>";
 include("../common/footer.php");
 ?>
-</body></html>
+
 

--- a/www/htdocs/central/utilities/inc_show_work.php
+++ b/www/htdocs/central/utilities/inc_show_work.php
@@ -3,6 +3,7 @@
 20210607 fho4abcd Created from vmx_import_iso.php
 20210702 fho4abcd added scriptaction="matchisofdt"
 20210802 fho4abcd Make Show file work the first time
+20211214 fho4abcd New icons. Simplified layout
 */
 /*
 ** Function : Combine the common part of actions operaing on the wrk folder
@@ -68,8 +69,10 @@ if ($confirmcount<=0) {  /* - First screen: Select the iso file -*/
          <tr>
             <td><?php echo $wrkfolder_label;?></td><td><?php echo $wrkfolder_value;?></td>
         </tr>
-       <tr><td align=center colspan=2>
-                <input type=button value='<?php echo $msgstr["uploadfile"];?>' onclick=Upload()></td>
+        <tr><td align=center colspan=2>
+                <a href="javascript:Upload()" class="bt bt-blue" title='<?php echo $msgstr["uploadfile"]?>'>
+                <i class="fas fa-file-upload"></i>&nbsp;<?php echo $msgstr["uploadfile"];?></a></td>
+        </tr>
     </table>
     </form>
     <?php
@@ -98,19 +101,11 @@ if ($confirmcount<=0) {  /* - First screen: Select the iso file -*/
         sort ($file_array);
         reset ($file_array);
         $actioncolmsg=$msgstr["seleccionar"];
-        $selimg="img src='../dataentry/img/aceptar.gif' alt='" .$msgstr["selfile"]."' title='".$msgstr["selfile"]."'";
         if ($scriptaction=="cnviso2utf") {
             $actioncolmsg=$msgstr["convert"];
-            $selimg="img src='../dataentry/img/barTool.png' alt='" .$msgstr["cnv_iso2utf"]."' title='".$msgstr["cnv_iso2utf"]."'";
         } else if ( $scriptaction=="matchisofdt") {
             $actioncolmsg=$msgstr["match"];
-            $selimg="img src='../dataentry/img/barTool.png' alt='" .$msgstr["matchisofdt"]."' title='".$msgstr["matchisofdt"]."'";
         }
-        $selimg=htmlentities($selimg);
-        $delimg="img src='../dataentry/img/barDelete.png' alt='" .$msgstr["eliminar"]."' title='".$msgstr["eliminar"]."'";
-        $delimg=htmlentities($delimg);
-        $lisimg="img src='../dataentry/img/preview.gif' alt='" .$msgstr["ver"]."' title='".$msgstr["ver"]."'";
-        $lisimg=htmlentities($lisimg);
         // Create a form with all necessary info
         // Show the list of iso files in /wrk
         ?>
@@ -135,13 +130,7 @@ if ($confirmcount<=0) {  /* - First screen: Select the iso file -*/
         </form>
 
         <h3><?php echo $msgstr["seleccionar"]." ".$msgstr["cnv_iso"]?> </h3>
-        <table bgcolor=#e7e7e7 cellspacing=1 cellpadding=4>
-        <tr>
-            <th><?php echo $msgstr["archivo"]?> </th>
-            <th><?php echo $msgstr["ver"]?> </th>
-            <th><?php echo $msgstr["eliminar"]?> </th>
-            <th><?php echo $actioncolmsg?> </th>
-       </tr>
+        <table style="border-collapse:collapse;"  cellpadding=5 >
         <?php
         foreach ($file_array as $file) {
             $filemsg="<b>".$file."</b><br>";
@@ -149,10 +138,26 @@ if ($confirmcount<=0) {  /* - First screen: Select the iso file -*/
             $filemsg.=", Size: ".number_format(filesize($wrkfull."/".$file),0,',','.');
         ?> 
         <tr>
-            <td bgcolor=white><?php echo $filemsg?></td>
-            <td bgcolor=white><a href="javascript:ActivarMx(<?php echo "'$wrk'"?>,<?php echo "'$file'"?>)"> <<?php echo $lisimg?>> </a></td>
-            <td bgcolor=white><a href="javascript:Eliminar('<?php echo $file?>')"> <<?php echo $delimg?>> </a></td>
-            <td bgcolor=white><a href="javascript:Seleccionar('<?php echo $file?>')"> <<?php echo $selimg?>> </a></td>
+            <td style="border-top: 1px solid var(--gray110);"><?php echo $filemsg?></td>
+            <td >
+                <a href="javascript:ActivarMx(<?php echo "'$wrk'"?>,<?php echo "'$file'"?>)" class="bt bt-gray" title='<?php echo $msgstr["ver"]?>'>
+                <i class="fas fa-tv"></i></a>
+                <a href="javascript:Eliminar('<?php echo $file?>')" class="bt bt-red" title='<?php echo $msgstr["eliminar"]?>'>
+                <i class="fas fa-trash-alt"></i></a>
+                <?php if ($scriptaction=="cnviso2utf") {
+                ?>
+                <a href="javascript:Seleccionar('<?php echo $file?>')" class="bt bt-green" title='<?php echo $msgstr["cnv_iso2utf"]?>'>
+                <i class="fas fa-wrench"></i>&nbsp;<?php echo $msgstr["convert"]?></a>
+                <?php } else if ( $scriptaction=="matchisofdt") {
+                ?>
+                <a href="javascript:Seleccionar('<?php echo $file?>')" class="bt bt-green" title='<?php echo $msgstr["matchisofdt"]?>'>
+                <i class="fas fa-hammer"></i>&nbsp;<?php echo $msgstr["match"]?></a>
+                <?php } else {
+                ?>
+                <a href="javascript:Seleccionar('<?php echo $file?>')" class="bt bt-green" title='<?php echo $importisomsg?>'>
+                <i class="fas fa-check"></i>&nbsp;<?php echo $msgstr["cnv_import"]?></a>
+                <?php } ?>
+            </td>
         </tr>
         <?php
         }

--- a/www/htdocs/central/utilities/match_iso_with_fdt.php
+++ b/www/htdocs/central/utilities/match_iso_with_fdt.php
@@ -2,6 +2,7 @@
 /* Modifications
 20210702 fho4abcd Created new
 20210802 fho4abcd Make Show file work the first time
+20211214 fho4abcd Backbutton by included file
 */
 global $arrHttp;
 set_time_limit(0);
@@ -117,12 +118,7 @@ if ($inframe!=1) include "../common/institutional_info.php";
 ?>
 	</div>
 	<div class="actions">
-<?php
-        $backtourl=$backtoscript."?base=".$arrHttp["base"];
-        echo "<a href='$backtourl'  class=\"defaultButton backButton\">";
-?>
-		<img src="../../assets/images/defaultButton_iconBorder.gif" alt="" title="" />
-		<span><strong><?php echo $msgstr["regresar"]?></strong></span></a>
+    <?php include "../common/inc_back.php";?>
 	</div>
 	<div class="spacer">&#160;</div>
 </div>
@@ -283,5 +279,5 @@ if ($confirmcount==1) {  /* - Second screen: Present a menu with parameters -*/
 echo "</div></div></div>";
 include("../common/footer.php");
 ?>
-</body></html>
+
 

--- a/www/htdocs/central/utilities/vmx_import_iso.php
+++ b/www/htdocs/central/utilities/vmx_import_iso.php
@@ -10,6 +10,7 @@
 20210605 fh04abcd Remove isotag1=3000 from command to avoid creation of extra fields. Translations
 20210624 fho4abcd Import only if second screen was executed (and not immediately during list presentation)
 20210802 fho4abcd Make Show file work the first time
+20211214 fho4abcd Backbutton by included file
 */
 global $arrHttp;
 set_time_limit(0);
@@ -90,12 +91,7 @@ if ($inframe!=1) include "../common/institutional_info.php";
 ?>
 	</div>
 	<div class="actions">
-<?php
-        $backtourl=$backtoscript."?base=".$arrHttp["base"];
-        echo "<a href='$backtourl'  class=\"defaultButton backButton\">";
-?>
-		<img src="../../assets/images/defaultButton_iconBorder.gif" alt="" title="" />
-		<span><strong><?php echo $msgstr["regresar"]?></strong></span></a>
+    <?php include "../common/inc_back.php";?>
 	</div>
 	<div class="spacer">&#160;</div>
 </div>
@@ -204,5 +200,4 @@ if ($confirmcount==1) {  /* - Second screen: Present a menu with parameters -*/
 echo "</div></div></div>";
 include("../common/footer.php");
 ?>
-</body></html>
 


### PR DESCRIPTION
This commit builds on the new look introduced some time ago.
- The back button is present on many screens in the breadcrumb/actions and fully coded in all these scripts. This commit introduces file common/inc_back.php. It is intended to replace the hard coded parts in all scripts that show this back button. With this approach it will be much easier to change the look&feel of that button.
- The new  back button is now present in 4 files:
  - menu_mantenimiento.php,
  - cnv_iso_2_utf.php
  - match_iso_with_fdt.php
  - vmx_import.php
Details of the other modifications:
- The Digital Documents submenu is transformed into a main menu item in the Utilities screen
- Operations on iso files ( import/match/convert) use the new menu button style