### PR TITLE
Run opac with language folder 00 in central

### DIFF
--- a/www/htdocs/opac_abcd/php/config_opac.php
+++ b/www/htdocs/opac_abcd/php/config_opac.php
@@ -1,6 +1,6 @@
 <?php
 /*
-20211224 fho4abcd Read default message file from central, with central processing
+20211224 fho4abcd Read default message file from central, with central processing, lineends
 */
 session_start();
 error_reporting(E_ALL);
@@ -25,10 +25,12 @@ if (isset($_SESSION["db_path"]))
 	$db_path=$_SESSION["db_path"];   //si hay multiples carpetas de bases de datos
 else
 	if (isset($_REQUEST["db_path"])) $db_path=$_REQUEST["db_path"];
-if (isset($_REQUEST["lang"])){	 $_SESSION["lang"]= $_REQUEST["lang"];
+if (isset($_REQUEST["lang"])){
+	 $_SESSION["lang"]= $_REQUEST["lang"];
 	 $lang=$_REQUEST["lang"];
 }
-// Read language files from centralinclude "../../central/lang/opac.php";
+// Read language files from central
+include "../../central/lang/opac.php";
 
 $actualScript=basename($_SERVER['PHP_SELF']);
 $CentralPath=$ABCD_scripts_path.$app_path."/";
@@ -115,9 +117,11 @@ else
 $db_path=trim(urldecode($db_path));
 $ix=explode('/',$db_path);
 $xxp="";
-for ($i=1;$i<count($ix);$i++) {	$xxp.=$ix[$i];
+for ($i=1;$i<count($ix);$i++) {
+	$xxp.=$ix[$i];
 	if ($i!=count($ix)-1) $xxp.='/';
-}
+
+}
 
 if (!isset($diagnostico)){
 	if (!is_dir($db_path."opac_conf")) {
@@ -125,7 +129,8 @@ if (!isset($diagnostico)){
 		echo "<a href=//wiki.abcdonline.info/index.php?title=OPAC-ABCD_configuración#Estructura_de_carpetas_y_archivos_de_configuraci.C3.B3n>".$msgstr["help"]."</a>";
         die;
 	}
-	if (!is_dir($db_path."opac_conf/$lang")) {		echo "<h3>".$msgstr["missing_folder"]."  $xxp opac_conf <font color=red>$lang</font><h3>";
+	if (!is_dir($db_path."opac_conf/$lang")) {
+		echo "<h3>".$msgstr["missing_folder"]."  $xxp opac_conf <font color=red>$lang</font><h3>";
 		echo "<a href=//wiki.abcdonline.info/index.php?title=OPAC-ABCD_configuraci&oacute;n#Estructura_de_carpetas_y_archivos_de_configuraci.C3.B3n>".$msgstr["help"]."</a>";
 		die;
 	}

--- a/www/htdocs/opac_abcd/php/config_opac.php
+++ b/www/htdocs/opac_abcd/php/config_opac.php
@@ -1,8 +1,11 @@
 <?php
+/*
+20211224 fho4abcd Read default message file from central, with central processing
+*/
 session_start();
 error_reporting(E_ALL);
 //CHANGE THIS ////
-include ("/abcd2.2/www/htdocs/central/config.php");   //CAMINO DE ACCESO HACIA EL CONFIG.PHP DE ABCD
+include ("../../central/config.php");   //CAMINO DE ACCESO HACIA EL CONFIG.PHP DE ABCD
 
 //LOS SIGUIENTES PARÁMETROS ESTÁN DEFINIDOS EN EL CONFIG.PHP DE LA VERSIÓN 2.2. SE INCLUYEN AQUÍ PARA
 //COMPATIBILIDAD CON LA VERSION 1.6
@@ -12,8 +15,7 @@ if (!isset($server_url)){
 	$server_url="http://localhost:9091";       //El url qaue se usa para acceder a ABCD
 	$OpacHttp=$server_url;
 }
-//
-if (!isset($charset)) $charset="ISO-8859-1";
+
 if (!isset($_REQUEST["lang"]))
 	$_REQUEST["lang"]=$lang;
 else
@@ -25,7 +27,10 @@ else
 	if (isset($_REQUEST["db_path"])) $db_path=$_REQUEST["db_path"];
 if (isset($_REQUEST["lang"])){	 $_SESSION["lang"]= $_REQUEST["lang"];
 	 $lang=$_REQUEST["lang"];
-}$actualScript=basename($_SERVER['PHP_SELF']);
+}
+// Read language files from centralinclude "../../central/lang/opac.php";
+
+$actualScript=basename($_SERVER['PHP_SELF']);
 $CentralPath=$ABCD_scripts_path.$app_path."/";
 $CentralHttp=$server_url;
 $NovedadesDir="";
@@ -106,7 +111,7 @@ if ($showhide=="Y")
 	$showhide_help="block";
 else
 	$showhide_help="none";
-include("read_lang.php");
+
 $db_path=trim(urldecode($db_path));
 $ix=explode('/',$db_path);
 $xxp="";

--- a/www/htdocs/opac_abcd/php/read_lang.php
+++ b/www/htdocs/opac_abcd/php/read_lang.php
@@ -1,4 +1,5 @@
 <?php
+// 20211224 fho4abcd: This file can be replaced by ../../central/lang/opac.php
 if (isset($msg_path) and $msg_path!="")	$path=$msg_path;else	$path=$db_path;$a=$path."lang/00/opac.tab";
 iF (!isset($msgstr["menu_1"])) $msgstr["menu_1"]="LogOut";
 iF (!isset($msgstr["menu_2"])) $msgstr["menu_2"]="General";

--- a/www/htdocs/opac_abcd/php/read_lang.php
+++ b/www/htdocs/opac_abcd/php/read_lang.php
@@ -1,12 +1,40 @@
 <?php
-// 20211224 fho4abcd: This file can be replaced by ../../central/lang/opac.php
-if (isset($msg_path) and $msg_path!="")	$path=$msg_path;else	$path=$db_path;$a=$path."lang/00/opac.tab";
+// 20211224 fho4abcd: This file can be replaced by ../../central/lang/opac.php, lineends
+if (isset($msg_path) and $msg_path!="")
+	$path=$msg_path;
+else
+	$path=$db_path;
+$a=$path."lang/00/opac.tab";
 iF (!isset($msgstr["menu_1"])) $msgstr["menu_1"]="LogOut";
 iF (!isset($msgstr["menu_2"])) $msgstr["menu_2"]="General";
-if (file_exists($a)) {	$fp=file($a);	foreach($fp as $var=>$value){		if (trim($value)!="") {			$value=str_replace('"',"'",$value);
-			//$value=str_replace("'","'",$value);			$m=explode('=',$value,2);			$m[0]=trim($m[0]);			if (!isset($msgstr[$m[0]])) $msgstr[$m[0]]=trim($m[1]);		}	}}
+if (file_exists($a)) {
+	$fp=file($a);
+	foreach($fp as $var=>$value){
+		if (trim($value)!="") {
+			$value=str_replace('"',"'",$value);
+
+			//$value=str_replace("'","'",$value);
+			$m=explode('=',$value,2);
+			$m[0]=trim($m[0]);
+			if (!isset($msgstr[$m[0]])) $msgstr[$m[0]]=trim($m[1]);
+		}
+	}
+}
+
 $a=$path."/lang/".$_REQUEST["lang"]."/opac.tab";
-if (file_exists($a)) {	$fp=file($a);	foreach($fp as $var=>$value){		if (trim($value)!="") {			$value=str_replace('"',"'",$value);			//$value=str_replace("'","'",$value);			$m=explode('=',$value,2);			$m[0]=trim($m[0]);
+if (file_exists($a)) {
+	$fp=file($a);
+	foreach($fp as $var=>$value){
+		if (trim($value)!="") {
+			$value=str_replace('"',"'",$value);
+			//$value=str_replace("'","'",$value);
+			$m=explode('=',$value,2);
+			$m[0]=trim($m[0]);
 			if ($charset=="UTF-8")
-            	$m[1]=utf8_encode($m[1]);			$msgstr[$m[0]]=trim($m[1]);		}	}}
+            	$m[1]=utf8_encode($m[1]);
+			$msgstr[$m[0]]=trim($m[1]);
+		}
+	}
+}
+
 ?>


### PR DESCRIPTION
The 00 language folder was moved from the databases folder to central/lang/00 to ensure that it always exists with the translations used by code. This is also valid for opac and is now effected  by this change.