### PR TITLE
Preset configured language in login language selection dropdown

### DIFF
--- a/www/htdocs/central/common/footer.php
+++ b/www/htdocs/central/common/footer.php
@@ -11,7 +11,7 @@
 
 		<div class="footer">
 			<div class="systemInfo">
-				<span><b>ABCD v2.2.0-beta-0</b> + ... &rarr; 2021-12-23</span>
+				<span><b>ABCD v2.2.0-beta-0</b> + ... &rarr; 2022-01-19</span>
 				<span><?php if (isset($def["LEGEND1"])) echo $def["LEGEND1"]; ?></span>
 				<?php if(isset($def["URL1"])){
 					echo "<a href=".$def["URL1"]." target=_blank>". $def["URL1"]."</a>";

--- a/www/htdocs/central/common/inc_get-langtab.php
+++ b/www/htdocs/central/common/inc_get-langtab.php
@@ -3,6 +3,7 @@
 20210430 fho4abcd Created
 20210520 fho4abcd New location 00 file
 20210521 fho4abcd typo
+20220119 fho4abcd correct path to absolute default language table
 */
 /*--------------------------------------------------------------
 ** Function  : Select the best available language table file
@@ -36,7 +37,7 @@ function get_langtab () {
  	}
  	if (!file_exists($langtab_file)) {
         // Try absolute default language. 
- 		$langtab_file=dirname(__FILE__)."../lang/00/lang.tab";
+ 		$langtab_file=dirname(__FILE__)."/../lang/00/lang.tab";
  	}
  	if (!file_exists($langtab_file)){
 		echo "</select></form></table><div><font color=red>".$msgstr["flang"]." ".$langtab_file."</font></div>";

--- a/www/htdocs/central/common/inicio.php
+++ b/www/htdocs/central/common/inicio.php
@@ -6,6 +6,7 @@
 2021-04-30 fho4abcd Do not switch language if selection is empty
 2021-06-14 fho4abcd Do not set password in $_SESSION + lineends
 2021-08-12 fho4abcd Give message if profiles/adm is missing for emergency user
+2022-01-19 fho4abcd Set default language if none supplied
 */
 global $Permiso, $arrHttp,$valortag,$nombre;
 $arrHttp=Array();
@@ -388,7 +389,11 @@ include("../lang/acquisitions.php");
 		VerificarUsuarioLDAP();
 	else
 		VerificarUsuario();
-		$_SESSION["lang"]=$arrHttp["lang"];
+        if (isset($arrHttp["lang"]) && $arrHttp["lang"]!="") {
+            $_SESSION["lang"]=$arrHttp["lang"];
+        } else {
+            $_SESSION["lang"]=$lang;
+        }
 		$_SESSION["login"]=$arrHttp["login"];
 		$_SESSION["nombre"]=$nombre;
 

--- a/www/htdocs/central/common/institutional_info.php
+++ b/www/htdocs/central/common/institutional_info.php
@@ -5,6 +5,7 @@
 20210415 fho4abcd Show db characterset if available, otherwise meta characterset. No longer show difference
 20211220 rogercgui Moved script from dataentry to common
 20211221 fho4abcd improved path to logout.php
+20220119 fho4abcd add empty value in language menu to indicate to no language matches
 */
 ?>
 
@@ -304,6 +305,7 @@ function ChangeLang(){
             $a=get_langtab();
             $fp=file($a);
             $selected="";
+            echo "<option title='' value=''"."</option>";
             foreach ($fp as $value){
                 $value=trim($value);
                 if ($value!=""){
@@ -328,6 +330,7 @@ function ChangeLang(){
 				        $a=get_langtab();
 				        $fp=file($a);
 				        $selected="";
+                        echo "<option title='' value=''"."</option>";
 				        foreach ($fp as $value){
 				            $value=trim($value);
 				            if ($value!=""){

--- a/www/htdocs/index.php
+++ b/www/htdocs/index.php
@@ -5,6 +5,8 @@
 2021-02-07 fho4abcd Configured Logo url now used without prefix and strip. Works now according to wiki
 2021-02-27 fho4abcd png favicon works better in bookmarks.
 2021-08-10 fho4abcd Do not crash if first language file (from the browser) is missing. Visible message if no file found
+2022-01-19 rogercgui Include css_settings.php
+2022-01-19 fho4abcd Configured language is preset in the language selection
 */
 session_start();
 $_SESSION=array();
@@ -13,10 +15,9 @@ include("central/config.php");
 include("$app_path/common/get_post.php");
 $new_window=time();
 //foreach ($arrHttp as $var=>$value) echo "$var = $value<br>";
-$lang_config=$lang;
 
+$lang_config=$lang; // save the configured language to preset it later
 $lang = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
-
 if (isset($_SESSION["lang"])){
 	$arrHttp["lang"]=$_SESSION["lang"];
 	$lang=$_SESSION["lang"];
@@ -26,8 +27,7 @@ if (isset($_SESSION["lang"])){
 }
 
 include ("$app_path/lang/admin.php");
-include ("$app_path/lang/lang.php");
-	
+include ("$app_path/lang/lang.php");	
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -197,22 +197,22 @@ if (isset($arrHttp["login"]) and $arrHttp["login"]=="N"){
         ?>
 			<label ><?php echo $msgstr["lang"]?></label> 
 			<select name=lang class="textEntry singleTextEntry" onchange="this.submit()">
-<?php
-
-		$fp=file($a);
-		$selected="";
-		foreach ($fp as $value){
-			$value=trim($value);
-			if ($value!=""){
-				$l=explode('=',$value);
-				if ($l[0]!="lang"){
-					if ($l[0]==$lang) $selected=" selected";
-					echo "<option value=$l[0] $selected>".$msgstr[$l[0]]."</option>\n";
-					$selected="";
-				}
-			}
-		}
-?>
+                <option value=''></option>
+                <?php
+                $fp=file($a);
+                $selected="";
+                foreach ($fp as $value){
+                    $value=trim($value);
+                    if ($value!=""){
+                        $l=explode('=',$value);
+                        if ($l[0]!="lang"){
+                            if ($l[0]==$lang_config) $selected=" selected";
+                            echo "<option value=$l[0] $selected>".$msgstr[$l[0]]."</option>\n";
+                            $selected="";
+                        }
+                    }
+                }
+                ?>
 			</select>
 		</div>
 		<div class="formRow"><br>


### PR DESCRIPTION
Note that the login screen is by default shown in the language of the browser.
The language dropdown took that also as preset, ignoring the preset language in abcd.def.
This modification preselects the preset language from abcd.def in the language dropdown.

The initial screen takes the browser language and if that is not available the fallback. This is the language set by config.php (may be the value set in abcd.def). Missing translations are given by the built-in 00 (if central/lang/00 is up to date)
