### PR TITLE
Update fdt_update.php: feedback and result

### DIFF
--- a/www/htdocs/central/dbadmin/fdt_update.php
+++ b/www/htdocs/central/dbadmin/fdt_update.php
@@ -1,120 +1,137 @@
 <?php
+/*
+20220128 fho4abcd improve back buttons + rewrite code to show more info+improve update of formatos.wks
+*/
 session_start();
 if (!isset($_SESSION["permiso"])){
-	header("Location: ../common/error_page.php") ;
+    header("Location: ../common/error_page.php") ;
 }
 include("../common/get_post.php");
 include ('../config.php');
-if (isset($_SESSION["UNICODE"])) {
-	IF ($_SESSION["UNICODE"]==1)
-		$meta_encoding="UTF-8";
-	else
-		$meta_encoding="ISO-8859-1";
-}
 $lang=$_SESSION["lang"];
 
+include("../lang/admin.php");
 include("../lang/dbadmin.php");
-//foreach ($arrHttp as $var=>$value)  echo "$var=$value<br>";//die;
-$archivo=$arrHttp["archivo"];
-$t=explode("\n",$arrHttp["ValorCapturado"]);
-$fp=fopen($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/".$archivo,"w");
-if (!$fp){
-	echo $arrHttp["base"]."/def/".$_SESSION["lang"]."/".$archivo." cannot be opened for writing";
-	die;
-}
-
-foreach ($t as $value){
-	$val=trim(str_replace('|','',$value));
-	if ($val=="00") $val="";
-	if ($val!="") fwrite($fp,stripslashes($value)."\n");
-	//echo "$value<br>";
-}
-// IF THE FDT IS A FORMAT UPDATE THE FILE FORMATOS.DAT
-if (isset($arrHttp["fmt_name"])){
-	if (file_exists(($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/formatos.wks"))){
-		$fp=file($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/formatos.wks");
-	}else{
-		if (file_exists(($db_path.$arrHttp["base"]."/def/".$lang_db."/formatos.wks")))
-			$fp=file($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/formatos.wks");
-	}
-	$fex="N";
-	if ($fp){
-		foreach ($fp as $linea){
-			$linea=trim($linea);
-			if ($linea!=""){
-				$l=explode('|',$linea);
-				if (trim($l[0])==trim($arrHttp["fmt_name"]))
-					$fex="S";
-				$salida[]=$linea;
-			}
-		}
-	}
-	//IF IS A NEW FORMAT
-	if ($fex=="N"){
-		$fp=fopen($db_path.$arrHttp["base"]."/def/".$_SESSION["lang"]."/formatos.wks","w");
-		if (!$fp){
-			echo "the file could not be updated";
-			die;
-		}
-		foreach ($salida as $arch) $res=fwrite($fp,$arch."\n");
-		$res=fwrite($fp,$arrHttp["fmt_name"].'|'.$arrHttp["fmt_desc"]);
-		fclose($fp); #close the file
-	}
-
-}
 include("../common/header.php");
 ?>
 <body>
 <?php
-$encabezado="";
 if (isset($arrHttp["encabezado"])){
-	include("../common/institutional_info.php");
+    $encabezado="&encabezado=s";
+} else {
+    $encabezado="";
+}
+if (isset($arrHttp["encabezado"])){
+    include("../common/institutional_info.php");
+}
+$isfdt=true;
+if (isset($arrHttp["fmt_name"])) $isfdt=false;
+?>
+<div class="sectionInfo">
+    <div class="breadcrumb">
+        <?php
+            if ($isfdt ) echo $msgstr["updfdt"];
+            if (!$isfdt) echo $msgstr["fmtupdate"];
+            echo "&rarr; ".$msgstr["database"].": ". $arrHttp["base"];
+        ?>
+    </div>
+    <div class="actions">
+        <?php    
+        if (isset($arrHttp["Fixed_field"])) {
+            $backtoscript ="<a href=fixed_marc.php?base=". $arrHttp["base"].$encabezado;
+                include "../common/inc_back.php";
+                include "../common/inc_home.php";
+        } else {
+            if (!isset($arrHttp["ventana"])) {
+                $backtoscript = "menu_modificardb.php?base=". $arrHttp["base"].$encabezado;
+                include "../common/inc_back.php";
+                include "../common/inc_home.php";
+            } else {
+                include "../common/inc_close.php";
+            }
+        }
+        ?>
+</div>
+<div class="spacer">&#160;</div>
+</div>
+<?php include "../common/inc_div-helper.php" ?>
+<div class="middle form">
+    <div class="formContent">
+<?php
+//foreach ($arrHttp as $var=>$value)  echo "$var=$value<br>";
+
+// Write the content of ValorCapturado to the file
+$archivo=$arrHttp["archivo"];
+$archivobase=$arrHttp["base"]."/def/".$lang."/".$archivo;
+$archivolang=$db_path.$arrHttp["base"]."/def/".$lang;
+$archivofull=$db_path.$archivobase;
+$t=explode("\n",$arrHttp["ValorCapturado"]);
+if (!file_exists($archivolang)) mkdir ($archivolang);
+$fp=@fopen($archivofull,"w");
+if (!$fp){
+    echo "<div style='color:red'>".$msgstr["cwritefile"].": ".$archivobase;
+    include ("../common/footer.php");
+    die;
+}
+
+foreach ($t as $value){
+    $val=trim(str_replace('|','',$value));
+    if ($val=="00") $val="";
+    if ($val!="") fwrite($fp,stripslashes($value)."\n");
+    //echo "$value<br>";
+}
+// The file is updated now: send a message
+echo "<h2>".$msgstr["updated"]." : ".$archivobase."</h2>";
+
+// IF THE FDT IS A FORMAT also UPDATE THE FILE formatos.wks
+$formatos=$arrHttp["base"]."/def/".$lang."/formatos.wks";
+$formatosfull=$db_path.$formatos;
+$formatos2=$arrHttp["base"]."/def/".$lang_db."/formatos.wks";
+$formatos2full=$db_path.$formatos2;
+if (isset($arrHttp["fmt_name"])){
+    if (file_exists(($formatosfull))){
+        $fp=file($formatosfull);
+        $updateformatos="default";
+    }else{
+        if (file_exists(($formatos2full))){
+            $fp=file($formatos2full);
+            $updateformatos="forced";
+        }
+    }
+    $fex="N";
+    // Read the content of the formatos file (of the current or default language)
+    // If there is no formatos file for the current language the default language gives a good start
+    if ($fp){
+        foreach ($fp as $linea){
+            $linea=trim($linea);
+            if ($linea!=""){
+                $l=explode('|',$linea);
+                if (trim($l[0])==trim($arrHttp["fmt_name"]))
+                    $fex="S";
+                $salida[]=$linea;
+            }
+        }
+    }
+    //IF IS A NEW FORMAT: write to the current language
+    if ($fex=="N" || $updateformatos=="forced"){
+        $fp=@fopen($formatosfull,"w");
+        if (!$fp){
+            echo "<div style='color:red'>".$msgstr["cwritefile"].": ".$formatos;
+            include ("../common/footer.php");
+            die;
+        }
+        foreach ($salida as $arch) {
+            // in case of forced update do not write duplicate
+            if ($arch != $arrHttp["fmt_name"].'|'.$arrHttp["fmt_desc"]){
+                $res=fwrite($fp,$arch."\n");
+            }
+        }
+        $res=fwrite($fp,$arrHttp["fmt_name"].'|'.$arrHttp["fmt_desc"]);
+        fclose($fp); #close the file
+        echo "<h3>".$msgstr["updated"]." : ".$formatos."</h3>";
+    }
 }
 ?>
-	<div class="sectionInfo">
-			<div class="breadcrumb">
-				<h5>
-				<?php echo 	$msgstr["fdt"]." " .$msgstr["database"]. ": " . $arrHttp["base"]; ?>
-					
-				</h5>
-			</div>
-
-			<div class="actions">
-				<?php	
-				if (isset($arrHttp["encabezado"])){
-					$encabezado="&encabezado=s";
-				} else {
-					$encabezado="";
-				}
-
-				if (isset($arrHttp["Fixed_field"])) {
-					echo "<a href=fixed_marc.php?base=". $arrHttp["base"].$encabezado." class=\"defaultButton backButton\">";
-				} else {
-				
-					if (!isset($arrHttp["ventana"])) {
-						$backtoscript = "menu_modificardb.php?base=". $arrHttp["base"].$encabezado;
-						include "../common/inc_back.php";
-
-					 } else {
-
-						$backtoscript = "javascript:self.close()";
-						include "../common/inc_back.php";
-				}
-
-			}
-				?>
-	</div>
-
-	<div class="spacer">&#160;</div>
-
-	</div>
-
-	<?php include "../common/inc_div-helper.php" ?>
-
-	<div class="middle form">
-		<div class="formContent">
-	 		<h2><?php echo $msgstr["fdtupdated"];?> </h2>
-		</div>
-	</div>
-
+</div>
+</div>
 <?php include ("../common/footer.php"); ?>

--- a/www/htdocs/central/lang/00/dbadmin.tab
+++ b/www/htdocs/central/lang/00/dbadmin.tab
@@ -149,6 +149,7 @@ fmtplsselect=Please select a worksheet
 fmtcreated=Data entry worksheet created
 fmtmisdes=Missing worksheet Description
 fmtmisname=Missing worksheet Name
+fmtupdate=Update FMT
 fmtupdated=The dataentry Worksheet has been updated
 fn=Field name
 folderne=Folder does not exists


### PR DESCRIPTION
This script is used to update FDT and FMT files.
- breadcrumb shows the type
- Error messages are translated and show the filename (not full, from base)
- Create and update of formatos.wks is improved and has its own feedback message
- The language folder  <db>/def/<lang> is created if not present to receive the fdt/fmt/formatos.wks