### PR TITLE
Show back-button if used in dataentry

### DIFF
--- a/www/htdocs/central/dataentry/administrar.php
+++ b/www/htdocs/central/dataentry/administrar.php
@@ -10,6 +10,7 @@
 20211216 fho4abcd Backbutton by included file, removed redundant help
 20220107 fho4abcd Removed opcion parameter for text import/export. Smaller textblocks
 20220124 fho4abcd No back button if institutional info not shown
+20220227 fho4abcd Always show backbutton. Other back if institutional info not shown
 */
 session_start();
 if (!isset($_SESSION["permiso"])){
@@ -112,7 +113,14 @@ if (isset($arrHttp["encabezado"]) and $arrHttp["encabezado"]=="s"){
 	<?php echo $msgstr["mantenimiento"]?>
     </div>
     <div class="actions">
-    <?php if ($arrHttp["encabezado"]=="s") include "../common/inc_back.php";?>
+        <?php
+        if ($arrHttp["encabezado"]=="s") {
+            include "../common/inc_back.php";
+        } else {
+            $backtoscript="../dataentry/inicio_main.php";
+            include "../common/inc_back.php";
+        }
+        ?>
     </div>
 		<div class="spacer">&#160;</div>
 	</div>

--- a/www/htdocs/central/dbadmin/pft.php
+++ b/www/htdocs/central/dbadmin/pft.php
@@ -6,6 +6,7 @@
 2022-01-25 fho4abcd more new look buttons, shift Generate output to the bottom, improve generate output layout
 2022-01-26 fho4abcd Open preview in larger window and after all checks passed.
 2022-01-29 fho4abcd Improve setting of encabezado+create language folder if it does not exist
+20220227 fho4abcd Always show backbutton. Other back if institutional info not shown
 */
 
 //error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING);
@@ -618,7 +619,10 @@ if ($arrHttp["Opcion"]=="new"){
 		}else{
             include("../common/inc_home.php");
 		}
-	} // end if encabezado
+	} else {
+        $backtoscript="../dataentry/inicio_main.php";
+        include "../common/inc_back.php";
+    }// end if encabezado
 }
 ?>
     </div>

--- a/www/htdocs/central/statistics/tables_generate.php
+++ b/www/htdocs/central/statistics/tables_generate.php
@@ -4,6 +4,7 @@
 20220220 fho4abcd Make search for MFN and by expression equal to Reports.
 20220220 fh04abcd The option to search by date is covered by expression (and better) : removed completely
 20220220 fh04abcd Removed global process: too much code fails. Unclear what it should do. Sanitized html
+20220227 fho4abcd Always show backbutton. Other back if institutional info not shown
 */
 // ==================================================================================================
 // GENERA LOS CUADROS ESTADÍSTICOS
@@ -281,9 +282,12 @@ if (isset($arrHttp["encabezado"])){
 
 	<div class="actions">
     <?php
-    if (isset($arrHttp["encabezado"])){
-        include "../common/inc_back.php";
-    }
+        if (isset($arrHttp["encabezado"])) {
+            include "../common/inc_back.php";
+        } else {
+            $backtoscript="../dataentry/inicio_main.php";
+            include "../common/inc_back.php";
+        }
     ?>
     </div>
     <div class="spacer">&#160;</div>


### PR DESCRIPTION
The back-button was considered unnecessary when there scripts were used during data-entry (All data entry icons are available to choose from). This consideration was not felt by all users so the back-button is shown again with same effect as the selection of Data entry from the Home page