### PR TITLE
Add remarks to create logs folder manually

### DIFF
--- a/zz_installation/vhost_ABCD_9090_Linux.conf
+++ b/zz_installation/vhost_ABCD_9090_Linux.conf
@@ -8,6 +8,7 @@
 # Prerequisite : Check modules in conf/httpd.conf:
 #                To enable symlinks
 #                   LoadModule rewrite_module modules/mod_rewrite.so
+# Prerequisite : Create folder ${ABCD_ROOT}/logs manually to prevent webserver start problems
 # Test         : Command line : "httpd -S" shows possible errors
 ######################
 Define ABCD_PORT 9090
@@ -61,6 +62,7 @@ Listen ${ABCD_PORT}
     # If the filenames do *not* begin with "/", the value of ServerRoot is prepended
     # - keyword "combined" is defined in httpd.conf
     # - Portnumber in log file names
+    # !! Create folder ${ABCD_ROOT}/logs manually !!
     CustomLog ${ABCD_ROOT}/logs/access_${ABCD_PORT}.log combined
     ErrorLog  ${ABCD_ROOT}/logs/error_${ABCD_PORT}.log
     # default log
@@ -69,6 +71,7 @@ Listen ${ABCD_PORT}
     
     # PHP flags work if php is installed
     # reporting -1 = E_ALL
+    # !! Create folder ${ABCD_ROOT}/logs manually !!
     php_flag  log_errors      on
     php_flag  display_errors  on
     php_value error_reporting -1 

--- a/zz_installation/vhost_ABCD_9090_Windows.conf
+++ b/zz_installation/vhost_ABCD_9090_Windows.conf
@@ -8,6 +8,7 @@
 # Prerequisite : Check modules in conf/httpd.conf:
 #                To enable symlinks
 #                   LoadModule rewrite_module modules/mod_rewrite.so
+# Prerequisite : Create folder ${ABCD_ROOT}/logs manually to prevent webserver start problems
 # Test         : Command line : "httpd -S" shows possible errors
 ######################
 Define ABCD_PORT 9090
@@ -61,6 +62,7 @@ Listen ${ABCD_PORT}
     # If the filenames do *not* begin with "/", the value of ServerRoot is prepended
     # - keyword "combined" is defined in httpd.conf
     # - Portnumber in log file names
+    # !! Create folder ${ABCD_ROOT}/logs manually !!
     CustomLog ${ABCD_ROOT}/logs/access_${ABCD_PORT}.log combined
     ErrorLog  ${ABCD_ROOT}/logs/error_${ABCD_PORT}.log
     # default log
@@ -69,6 +71,7 @@ Listen ${ABCD_PORT}
     
     # PHP flags work if php is installed
     # reporting -1 = E_ALL
+    # !! Create folder ${ABCD_ROOT}/logs manually !!
     php_flag  log_errors      on
     php_flag  display_errors  on
     php_value error_reporting -1 


### PR DESCRIPTION
The web server does not start if the vhost files has errors.
A missing folder to log webserver actions is considered an error. Remarks are added to create that folder to warn the installer