### PR TITLE
Write empty shortcut.pft files

### DIFF
--- a/www/htdocs/central/dbadmin/iah_edit_db.php
+++ b/www/htdocs/central/dbadmin/iah_edit_db.php
@@ -1,6 +1,7 @@
 <?php
 /*
 20220717 fho4abcd Use $actparfolder as location for .par & def files
+20220822 fho4abcd Improve checks&feedback if INDEX name is empty, skip if name&def are empty
 */
 session_start();
 if (!isset($_SESSION["permiso"])){
@@ -24,7 +25,9 @@ if (strpos($arrHttp["base"],"|")===false){
 }
 //foreach ($arrHttp as $var=>$value) echo "$var=$value<br>";
 include("../common/header.php");
-
+?>
+<body>
+<?php
 function AddKey($preliteral,$value){
 global $search_ix;
 	$ix=-1;
@@ -590,6 +593,10 @@ function Validar(){
 			alert("<?php echo $msgstr["indexdef"]?>: <?php echo $msgstr["missindconf"]?>")
 			return
 		}
+		if (def!="" && name==""){
+			alert("<?php echo $msgstr["indexdef"]?>: <?php echo $msgstr["missindex"]?>")
+			return
+		}
 // CHECK IF THE MAIN INDEX IS DEFINED
 		ixpos=def.indexOf("^d")
 		if (ixpos!=-1){
@@ -617,12 +624,14 @@ function Validar(){
 			}
 		}
 //CHECK IF AT LEAST ONE NAME IS SUPPLIED FOR THE INDEX
-        val_res=CheckNames(def)
-        if (!val_res) {
-        	alert("<?php echo $msgstr["misslang"]?> "+name)
-        	return false
+        if (name!=""&&def!=""){
+            val_res=CheckNames(def)
+            if (!val_res) {
+                alert("<?php echo $msgstr["misslang"]?> "+name)
+                return false
+            }
+            if (name+def!="") index_str+=name+"="+def+"\n"
         }
-		if (name+def!="") index_str+=name+"="+def+"\n"
 	}
     if (tmain==0 || tmain>1){
     	alert("<?php echo $msgstr["missdup_d"]?>")
@@ -772,11 +781,6 @@ function SubirOpcion(){
 	document.iah_edit.preferences.selectedIndex=ix-1
 }
 </script>
-</head>
-<body>
-
-
-
 <?php
 if (isset($arrHttp["encabezado"])){
 	include("../common/institutional_info.php");
@@ -895,7 +899,7 @@ include "../common/inc_div-helper.php";
 	<a href=#APPLY_GIZMO>[APPLY GIZMO]</A>&nbsp;&nbsp;<a href=#FORMAT_NAME>[FORMAT NAME]</A>&nbsp;&nbsp;<A HREF=#HELP_FORM>[HELP FORM]</A>
 	&nbsp;&nbsp;<A HREF=#PREFERENCES>[PREFERENCES]</A>
 	</DIV>";
-	echo "<a href=javascript:ValidateForm()>".$msgstr["validate"]."</a>";
+	echo "<br><a href=javascript:ValidateForm()>".$msgstr["validate"]."</a>";
 
 	foreach ($db_def as $var=>$value){
         $var=trim($var);

--- a/www/htdocs/central/dbadmin/iah_save.php
+++ b/www/htdocs/central/dbadmin/iah_save.php
@@ -1,6 +1,7 @@
 <?php
 /*
 20220717 fho4abcd Use $actparfolder as location for .par & def files
+20220822 fho4abcd Create shortcut.pft files if needed
 */
 session_start();
 if (!isset($_SESSION["permiso"])){
@@ -12,6 +13,7 @@ $lang=$_SESSION["lang"];
 
 include("../lang/iah_conf.php");
 include("../lang/dbadmin.php");
+include("../lang/soporte.php");
 
 if (strpos($arrHttp["base"],"|")===false){
 
@@ -71,9 +73,57 @@ include "../common/inc_div-helper.php";
 	$res=fwrite($fp,$arrHttp["ValorCapturado"]);
 
 	fclose($fp);
-	echo "<h2>".$msgstr["saved"];
+	echo "<h3>".$msgstr["saved"]." ".$file."</h3>";
+    /*
+    ** Write an initial shortcut.pft if required and possible
+    ** This might need the languages
+    */
+    $iah_def=parse_ini_file("../../iah/scripts/iah.def.php");
+    $iah_lang=explode(',',$iah_def["AVAILABLE LANGUAGES"]);
+    // Get the value of FILE SHORTCUT.IAH
+    $db_def=parse_ini_file ($file,true,INI_SCANNER_RAW);
+	if (isset($db_def["FILE_LOCATION"]["FILE SHORTCUT.IAH"])){
+        $shortcut_iah=$db_def["FILE_LOCATION"]["FILE SHORTCUT.IAH"];
+        // replace %path_database%
+        $shortcut_iah=str_replace("%path_database%",$db_path."/",$shortcut_iah);
+        // Check for %lang%
+        if ( strpos($shortcut_iah,"%lang%") === false) {
+            // No language indicator: use the filename
+            CrearArchivo($shortcut_iah);
+        } else {
+            foreach ($iah_lang as $value){
+                $lan_iah=trim($value);
+                // replace %lang%
+                $shortcut_iah_lang=str_replace("%lang%",$lan_iah."/",$shortcut_iah);
+                CrearArchivo($shortcut_iah_lang);
+            }
+        }
+                
+    }
 	?>
 	</div>
 
 </div>
 <?php include("../common/footer.php");?>
+<?php
+/* ----------------------------------------------*/
+function CrearArchivo($filename){
+    global $msgstr;
+    if (file_exists($filename)) {
+        echo $msgstr["fileexists"].": '".$filename."'<br>";
+        return(0);
+    }
+	if (!$handle = fopen($filename, 'w')) {
+        echo "<span style='color:red'>".$msgstr["copenfile"]." '".$filename."'</span><br>";
+        return -1;
+   	}
+    // Write the content to our opened file.
+    if (fwrite($handle, '') === FALSE) {
+        echo "<span style='color:red'>".$msgstr["cwritefile"]." '".$filename."'</span><br>";
+        return -1;
+    }
+    fclose($handle);
+    echo "<b>".$msgstr["createdemptyfile"]."</b> '".$filename."'<br>";
+    return 0;
+}
+?>

--- a/www/htdocs/central/lang/00/soporte.tab
+++ b/www/htdocs/central/lang/00/soporte.tab
@@ -155,6 +155,7 @@ copyfolder=Copy folder
 copyfrom=Copy from
 copyloanobjects=Copy/Loan objects
 cpdb=Copy definition from
+createdemptyfile=Created empty file
 createdfile=Created file
 createdfolder=Created folder
 create_gizmo=Create gizmo database


### PR DESCRIPTION
For iAH there needs to be a file 'shortcut.pft', containing links - if any, can also be left empty - to external PFTs e.g. for production of bibliographic lists like for Reference Manager, which needs to be correctly referenced to in the DBN.def file.
iah_save.php:
  - Gets the value of FILE SHORTCUT.IAH,
  - replaces %path_database%,
  - If the value does not contain %lang% an empty file is created if not present
  - if the value contains %lang% then for each iah languages an empty file is created if not present
iah_edit.php:
  - Some small error corrections. Not ideal but it works now