### PR TITLE
Update inc_close.php

### DIFF
--- a/www/htdocs/central/common/inc_close.php
+++ b/www/htdocs/central/common/inc_close.php
@@ -8,4 +8,3 @@ Usage     : <?php include "../common/inc_close.php" ?>
 ?>
 <a href="javascript:self.close()" class="bt bt-red" title='<?php echo $msgstr["cerrar"]?>'>
     <i class="far fa-window-close"></i>&nbsp;<?php echo $msgstr["cerrar"]?></a>
-<?php


### PR DESCRIPTION
Removed empty PHP statement. It was causing the error below on Linux servers:

Parse error: syntax error, unexpected end of file in /ABCD/www/htdocs/central/common/inc_close.php on line 11