### PR TITLE
Improve iso import/export for marc databases

### DIFF
--- a/www/htdocs/central/dataentry/exporta_txt_ex.php
+++ b/www/htdocs/central/dataentry/exporta_txt_ex.php
@@ -15,6 +15,7 @@
 2021-06-05 fho4abcd Export without marc without isotag. Export with marc with iso=marc + isotag.
 20211216 fho4abcd Backbutton by included file
 20220711 fho4abcd Use $actparfolder as location for .par files
+20221216 fho4abcd No longer use 'marc=' in command. The outisotag1=3000 seems sufficient
 */
 
 global $arrHttp;
@@ -212,10 +213,6 @@ function ExportarMX( $fullpath){
     global $mx_path,$db_path,$arrHttp,$msgstr;
     $strINV = $mx_path." db=".$db_path.$arrHttp["base"]."/data/".$arrHttp["base"];
     $strINV.= " iso=";
-    // Enter the marc special
-    if (isset($arrHttp["usemarcformat"]) and $arrHttp["usemarcformat"]=="on") {
-        $strINV.="marc=";
-    }
     $strINV.= $fullpath;
 
     // Enter the range

--- a/www/htdocs/central/lang/00/soporte.tab
+++ b/www/htdocs/central/lang/00/soporte.tab
@@ -291,6 +291,7 @@ testmx=Test
 tolinux=Delete carriage return (Windows -> Linux)
 transferido=Uploaded
 unch_append=Unchecked = Append records
+unch_noleaderimport=Unchecked = No import of MARC-Leader information
 unch_wxis=Unchecked = Use WXIS
 updatedfile=Updated file
 upload_conf_errmsg=May be a configuration error for file uploads. Check log files and php.ini.
@@ -299,6 +300,7 @@ upload_logout=Logout recommended
 upload_overwrite=Overwrite existing file ?
 upload_size=Size
 upload_status=Status
+useimportisotag=Use option 'isotag1'
 uni_no=No
 uni_yes=Yes
 validate=Validate

--- a/www/htdocs/central/utilities/vmx_import_iso.php
+++ b/www/htdocs/central/utilities/vmx_import_iso.php
@@ -11,6 +11,7 @@
 20210624 fho4abcd Import only if second screen was executed (and not immediately during list presentation)
 20210802 fho4abcd Make Show file work the first time
 20211214 fho4abcd Backbutton by included file
+20221216 fho4abcd Add button to import marc leader information
 */
 global $arrHttp;
 set_time_limit(0);
@@ -144,6 +145,10 @@ if ($confirmcount==1) {  /* - Second screen: Present a menu with parameters -*/
               <td><input type=checkbox name=delrec></td>
               <td><font color=blue><?php echo $msgstr["unch_append"]?></font></td>
           </tr><tr>
+              <td><?php echo $msgstr["useimportisotag"]?></td>
+              <td><input type=checkbox name=importisotag></td>
+              <td><font color=blue><?php echo $msgstr["unch_noleaderimport"]?></font></td>
+          </tr><tr>
               <td></td><td><input type=button value='START' onclick=Confirmar()></td><td></td>
          </tr>       
         </table>
@@ -171,7 +176,12 @@ if ($confirmcount==1) {  /* - Second screen: Present a menu with parameters -*/
 	else
 		$accion=" append";
 
-    $strINV=$mx_path." iso=$fullisoname $accion=".$db_path.$base."/data/".$base."  -all now 2>&1";
+    if (isset($arrHttp["importisotag"]))
+        $importisotag="isotag1=3000";
+    else
+        $importisotag="";
+
+    $strINV=$mx_path." iso=$fullisoname $accion=".$db_path.$base."/data/".$base." $importisotag  -all now 2>&1";
     exec($strINV, $output,$status);
     $straux="";
     for($i=0;$i<count($output);$i++){


### PR DESCRIPTION
The iso export code for marc databases no longer uses the mx option iso=marc=filename. Only outisotag1 is used. Effect is that correct iso files with record length=80 are produced

The iso import code has an extra option to specify the application of isotag1 in the import command. When selected the import command uses isotag1=3000 and import the leader info of marc databases.
Note 1: The program does NOT help the importer with any detection if leader information is present or not