### PR TITLE
Repair layout problems in cataloging

### DIFF
--- a/www/htdocs/assets/css/styles.css
+++ b/www/htdocs/assets/css/styles.css
@@ -4,6 +4,7 @@
 ** 2022-12-11 fho4abcd Add moduleButton
 ** 2023-01-16 fho4abcd InstitutionalInfo:removed width. heading-database:improved layout and added attention entry. table.toolbar-dataentry:increased width
 ** 2023-01-19 fho4abcd Removed unknown -webkit-text-size-adjust,-moz-box-shadow. bad !important
+** 2023-01-22 fho4abcd iframe settings in this file + adjust size of table-fdt-three
 */
 /* GENERAL STYLES */
 
@@ -1305,17 +1306,25 @@ iframe.dataentry-header {
 	height: 45px; 
 	width: 100%;
 	border: none;
-
 }
 
-.dataentry-menu {
-		border-bottom: 1px solid var(--abcd-gray-300);
+iframe.dataentry-menu {
+    position:relative;
+    height:77px;
+    width:100%;
+    border:none;
+    border-bottom: 1px solid var(--abcd-gray-300);
+}
+iframe.dataentry-main {
+    position:relative;
+    width:100%;
+    border:none;
 }
 
 
 body.toolbar-dataentry {
 	background: var(--abcd-light);
-	margin: 6px;
+	margin: 0px;
 	color: var(--abcd-steel-blue);
 }
 
@@ -1687,7 +1696,7 @@ td.table-fdt-one {
 
 /* NAME OF FIELD */
 .table-fdt-three {
-	width: 150px;
+	min-width: 150px;
 	font-size: 12px;
 }
 

--- a/www/htdocs/central/dataentry/inicio_main.php
+++ b/www/htdocs/central/dataentry/inicio_main.php
@@ -9,6 +9,7 @@
 2021-12-12 fho4abcd Improved sizeof popup for alfa (for breadcrumb)
 2022-03-20 fho4abcd Cleanup barcode, new target bcl_labelshow.php
 2022-06-19 fho4abcd Corrected html + removed unreachable js code + removed unreachable frameset
+2023-01-22 fho4abcd Improved height of iframe main. Moved css of iframes to css file
 */
 //error_reporting(E_ALL);
 session_start();
@@ -781,7 +782,7 @@ function Menu(Opcion){
 	}
 
 </script>
-
+<!--effect is no overall scrollbar-->
 <style type="text/css">
 	*, html {
 		height: 100%;
@@ -792,34 +793,31 @@ function Menu(Opcion){
     <?php
 	if (!isset($arrHttp["Mfn"])) $arrHttp["Mfn"]=0;
     ?> 
-	<iframe name="encabezado" id="encabezado" class="dataentry-header" scrolling="no" frameborder="0"
+	<iframe name="header" id="header" class="dataentry-header" 
         src="menubases.php?inicio=s&Opcion=Menu_o&base=<?php echo $bd;?>&cipar=<?php echo $bd;?>.par&Mfn=<?php echo $arrHttp['Mfn'];?>&base_activa=<?php echo $bd;?>&per=<?php echo $bdright;?>">
     </iframe>
-	<iframe name="menu"       id="menu"       class="dataentry-menu"   scrolling="no" frameborder="0" allowfullscreen wmode="transparent"
-        src="" style="width: 100%; height: 78px; position: relative;">
+	<iframe name="menu" id="menu"   class="dataentry-menu"
+        src="" >
     </iframe>
-	<iframe name="main"       id="main"
-        src="" style="width: 100%;               position: relative; border: none; ">
+	<iframe name="main" id="main"   class="dataentry-main";
+        src="" >
     </iframe>
 </div>
 
 <script>
     // Selecting the iframe element
-    var iframeEncabezado = document.getElementById("encabezado");
+    var iframeHeader = document.getElementById("header");
     var iframeMenu = document.getElementById("menu");
     var iframeMain = document.getElementById("main");
    
     // Adjusting the iframeMain height onload event
     iframeMain.onload = function() {
-    	var Todobody = window.screen.height;
-    	var encabezado = iframeEncabezado.contentWindow.document.body.scrollHeight
+    	var Todobody = window.innerHeight;
+    	var header = iframeHeader.contentWindow.document.body.scrollHeight
     	var menu = iframeMenu.contentWindow.document.body.scrollHeight
-    	var janela = iframeMain.contentWindow.document.body.scrollHeight
-	   	var toolbar = (encabezado + menu) * 2;
-	   	var valorfolga = -toolbar;
-        var folga = Todobody - toolbar;
+        var folga = Todobody - header - menu;
         iframeMain.style.height = folga + 'px';
-		//alert (folga);
+		//alert ("todobody="+Todobody+" toolbar="+toolbar+" folga="+folga);
     }
 </script>
 </body>


### PR DESCRIPTION
Solves the problem that it was sometimes not possible to scroll down to the bottom while stepping the records (missing footer or more) or editing the record (missing buttons or more). Solved by better computation of the height of iframe main. The other modifications in inicio_main.php are moving valid css attributes to styles.css and removing invalid attributes. Note that the layout is very slightly improved and the menu bar may show a scroll bar too in case of  a window that is much  too small.

Solves the problem that in certain circumstances in an edit session the dropdown menus shifted to a step to the right, so the layout of the form looked clumsy. Modified by settings of table-fdt-three in styles.css