### PR TITLE
Move config.php to a template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*/central/config.php

--- a/www/htdocs/central/config.php.template
+++ b/www/htdocs/central/config.php.template
@@ -17,6 +17,7 @@
 2022-02-22 fho4abcd  Added check on $_SESSION["lang"] + set $_SESSION["lang"]. This works for old scripts & updated scripts (without any lang settings)
 2022-03-21 fho4abcd  Added variable to set the par folder
 2022-03-31 fho4abcd  Replace fixed localhost by detection of the server name
+2023-02-23 fho4abcd  config.php->config.php.template
 */
 
 ini_set('error_reporting', E_ALL);

--- a/www/htdocs/central/config_inc_check.php
+++ b/www/htdocs/central/config_inc_check.php
@@ -1,0 +1,28 @@
+<?php
+/*
+** Check that the central config file is present.
+** If missing give hints that the file can be created from a template
+** Git has only the template, so avoid erroneous overwrites during installation
+** Text is only in English: supposed only to be read by application installers
+** Included before inclusion of config.php in some key files (no need to include everywhere)
+*/
+$def_config_file="central/config.php";
+$def_config_file_full=$_SERVER["DOCUMENT_ROOT"]."/".$def_config_file;
+$def_config_file_template=$def_config_file.".template";
+if (!is_readable($def_config_file_full) || filesize($def_config_file_full)<=0) {
+    ?>
+    <!DOCTYPE html><html><body>
+    <h3><font color=red>
+    <b>FATAL</b>: Configuration file: <b><?php echo $def_config_file?></b> does not exist, is empty or unreadable
+    </font></h3>
+    File location: <?php echo $def_config_file_full?><br><br>
+    Steps to resolve this:<ol>
+    <li>Copy <b><?php echo $def_config_file_template?></b> to <b><?php echo $def_config_file?></b></li>
+    <li>Edit <b><?php echo $def_config_file?></b> to reflect your local situation and save it</li>
+    <li>Check permissions and ownership: the webserver must be able to read the file!</li>
+    <li>Reload page</li></ol>
+    </body></html>
+    <?php
+    die;
+}
+?>

--- a/www/htdocs/central/config_opac.php
+++ b/www/htdocs/central/config_opac.php
@@ -2,10 +2,12 @@
 /*
 20211224 fho4abcd Read default message file from central, with central processing, lineends
 20220831 rogercgui Included the variable $opac_path to allow changing the Opac root directory
+20230223 fho4abcd Check for existence of config.php
 */
 //session_start();
 error_reporting(E_ALL);
-//CHANGE THIS ////
+//CHANGE THIS //// 
+include ("config_inc_check.php");
 include ("config.php");   //CAMINO DE ACCESO HACIA EL CONFIG.PHP DE ABCD
 
 if (isset($_SESSION["db_path"])){

--- a/www/htdocs/index.php
+++ b/www/htdocs/index.php
@@ -10,10 +10,12 @@
 20220122 rogercgui Default logo is displayed if institution image is absent
 20230127 fho4abcd Removed unused function, login fail can be caused by expiration: improve message content
                   Removed inline fixed size (clashed often with footer position). Removed unused div sectioninfo
+20230223 fho4abcd Check for existence of config.php
 */
 session_start();
 $_SESSION=array();
 unset($_SESSION["db_path"]);
+include("central/config_inc_check.php");
 include("central/config.php");
 include("$app_path/common/get_post.php");
 $new_window=time();

--- a/www/htdocs/mysite/index.php
+++ b/www/htdocs/mysite/index.php
@@ -1,5 +1,9 @@
 <?php
-
+/* Modifications
+20221029 fho4abcd Removed unused function, login fail can be caused by expiration: improve message content
+20230223 fho4abcd Check for existence of config.php
+*/
+include("../central/config_inc_check.php");
 include "../central/config.php";
 include "../$app_path/common/get_post.php";
 
@@ -29,7 +33,7 @@ include ("../$app_path/lang/lang.php");
 ?>
 <!DOCTYPE html>
 
-<html lang="<?php echo $lang;?>" lang="<?php echo $lang;?>">
+<html lang="<?php echo $lang;?>">
 
 <head>
 
@@ -134,10 +138,6 @@ include ("../$app_path/lang/lang.php");
             return true;
         }
 
-    function UsuarioNoAutorizado() {
-        alert("<?php echo $msgstr["menu_noau"]?>")
-    }
-
     function Enviar() {
         login = Trim(document.administra.login.value)
         password = Trim(document.administra.password.value)
@@ -188,7 +188,7 @@ include ("../$app_path/lang/lang.php");
 
     <?php
     if (isset($arrHttp["login"]) and $arrHttp["login"]=="N"){
-	    echo '<div class="alert alert-warning" role="alert">'.$msgstr["menu_noau"].'</div>';
+	    echo '<div class="alert alert-warning" role="alert">'.$msgstr["menu_ex_noau"].'</div>';
     }
 
     if (isset($arrHttp["login"]) and $arrHttp["login"]=="P"){

--- a/www/htdocs/odds/form_odds.php
+++ b/www/htdocs/odds/form_odds.php
@@ -3,6 +3,7 @@
 This is the page with the logic to display the main form of ODDS
 Modifications:
 20221210 fho4abcd Full rewrite (use msgstr,....)
+20230223 fho4abcd Check for existence of config.php
 */
 session_start(); 
 //The check for logged in is not done here (also no timeout etc)
@@ -15,6 +16,7 @@ if (isset($arrHttp["lang"]) and $arrHttp["lang"]!=""){
 	if (!isset($_SESSION["lang"])) $_SESSION["lang"]=$lang;
 }
 
+include("../central/config_inc_check.php");
 include("../central/config.php");
 $lang=$_SESSION["lang"];
 


### PR DESCRIPTION
To reduce erroneous overwriting a local config.php the original file is now available as template.
central/config.php is added to .gitignore