### PR TITLE
Corrects the UNICODE-MARCUNI

### DIFF
--- a/www/bases-examples_Linux/bases.dat
+++ b/www/bases-examples_Linux/bases.dat
@@ -1,17 +1,17 @@
+marc|MARC|Y
+marcuni|MARC-UTF8|Y
+dubcore|DublinCore Repository
+isadg|ISAD(G): International Standard Archival Description
+rda|RDA: Resource Description & Access|Y
 agrovoc|Agrovoc Thesaurus
 biblo|Cepal|Y
 dcdspace|dSpace Bridge
 doaj|DOAJ: Directory of Open Access Journals
-dubcore|DublinCore Repository
 experts|Experts
-isadg|ISAD(G): International Standard Archival Description
 projects|Projects
-marc|MARC|Y
-marcuni|MARCUNI|Y
-rda|RDA: Resource Description & Access|Y
-suggestions|Acq - Suggestions
 providers|Acq - Providers
 purchaseorder|Acq - Purchase Orders
+suggestions|Acq - Suggestions (Acquisitions)
 copies|Circ - Collection inventory
 loanobjects|Circ - Loan objects
 users|Circ - Patrons
@@ -19,4 +19,3 @@ reserve|Circ - Reservations
 suspml|Circ - Suspensions and fines
 trans|Circ - Transactions Loans
 acces|Sys - Administration Users/Operators (acces)
-unicode|Sys - UNICODE

--- a/www/bases-examples_Linux/marcuni/dr_path.def
+++ b/www/bases-examples_Linux/marcuni/dr_path.def
@@ -1,4 +1,5 @@
-ROOT=/var/opt/ABCD/bases/marc/dr/
+UNICODE=1
+ROOT=/ABCD/www/bases/marc/dr/
 tesaurus=agrovoc
 prefix_search_tesaurus=MA_
-barcode=Y
+DIRTREE_EXT=*.def,*.iso,*.png,*.gif,*.jpg,*.pdf,*.xrf,*.mst,*.n01,*.n02,*.l01,*.l02,*.cnt,*.ifp,*.fmt,*.fdt,*.pft,*.fst,*.tab,*.txt,*.par,*.html,*.zip,

--- a/www/bases-examples_Windows/bases.dat
+++ b/www/bases-examples_Windows/bases.dat
@@ -1,14 +1,14 @@
+marc|MARC|Y
+marcuni|MARC-UTF8|Y
+dubcore|DublinCore Repository
+isadg|ISAD(G): International Standard Archival Description
+rda|RDA: Resource Description & Access|Y
 agrovoc|Agrovoc Thesaurus
 biblo|Cepal|Y
 dcdspace|dSpace Bridge
 doaj|DOAJ: Directory of Open Access Journals
-dubcore|DublinCore Repository
 experts|Experts
-isadg|ISAD(G): International Standard Archival Description
-marc|MARC|Y
-marcuni|MARCUNI|Y
 projects|Projects
-rda|RDA: Resource Description & Access|Y
 providers|Acq - Providers
 purchaseorder|Acq - Purchase Orders
 suggestions|Acq - Suggestions (Acquisitions)
@@ -18,7 +18,4 @@ users|Circ - Patrons
 reserve|Circ - Reservations
 suspml|Circ - Suspensions and fines
 trans|Circ - Transactions Loans
-acces|Sys - Administration Users/Operators (acces) 
-servers|Servers z3950
-stock|Stock
-unicode|UNICODE
+acces|Sys - Administration Users/Operators (acces)

--- a/www/bases-examples_Windows/marcuni/dr_path.def
+++ b/www/bases-examples_Windows/marcuni/dr_path.def
@@ -1,3 +1,5 @@
+UNICODE=1
 ROOT=/ABCD/www/bases/marc/dr/
 tesaurus=agrovoc
 prefix_search_tesaurus=MA_
+DIRTREE_EXT=*.def,*.iso,*.png,*.gif,*.jpg,*.pdf,*.xrf,*.mst,*.n01,*.n02,*.l01,*.l02,*.cnt,*.ifp,*.fmt,*.fdt,*.pft,*.fst,*.tab,*.txt,*.par,*.html,*.zip,


### PR DESCRIPTION
Corrects the UNICODE parameter of the MARCUNI database; 
Changes the name MARCUNI to MARC-UTF-8 to avoid confusion with the UNIMARC standard.