### PR TITLE
Fixes the error caused by the absence of the ldap extension in php.ini.

### DIFF
--- a/www/htdocs/central/common/inicio.php
+++ b/www/htdocs/central/common/inicio.php
@@ -18,7 +18,10 @@ include("get_post.php");
 if (isset($arrHttp["db_path"]))
 	$_SESSION["DATABASE_DIR"]=$arrHttp["db_path"];
 require_once ("../config.php");
-require_once ("ldap.php");
+
+if ($use_ldap=="1") require_once ("ldap.php");
+
+
 //foreach ($arrHttp as $var=>$value) echo "$var=$value<br>";die;
 $valortag = Array();
 


### PR DESCRIPTION
To disable LDAP, set the variable $use_ldap in config.php to zero:
$use_ldap=0;

And comment with ";" in php.ini file:
;extension=ldap