### PR TITLE
Fix error "Function utf8_decode() is deprecated in..."

### DIFF
--- a/www/htdocs/central/common/wxis_llamar.php
+++ b/www/htdocs/central/common/wxis_llamar.php
@@ -168,7 +168,7 @@ $cset=strtoupper($meta_encoding);
 unset($cont_cnv);
 if ($cset=="UTF-8" and strtoupper($unicode)=="ANSI"){
     foreach ($contenido as $value){
-        $cont_cnv[]=utf8_encode($value);
+        $cont_cnv[]=mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1');
     }
     if (isset($cont_cnv))$contenido=$cont_cnv;
 }

--- a/www/htdocs/central/settings/opac/reservations_cnf.php
+++ b/www/htdocs/central/settings/opac/reservations_cnf.php
@@ -102,7 +102,7 @@ if (is_dir($db_path."reserve/pfts/".$_REQUEST["lang"])){
 	echo "<xmp>";
 	foreach ($fp as $value){
 		if ($charset=="UTF-8")
-			echo utf8_encode($value);
+			echo mb_convert_encoding($value,'UTF-8', 'ISO-8859-1');;
 		else
 			echo $value;
 	}

--- a/www/htdocs/central/settings/opac/xml_dc.php
+++ b/www/htdocs/central/settings/opac/xml_dc.php
@@ -211,9 +211,8 @@ global $msgstr,$db_path,$charset;
 			foreach ($value_campos as $value) {
 				if ($db_charset!=$charset){
 					if ($charset=="UTF-8" and $db_charset=="ISO-8859-1")
-					   $value=utf8_encode($value);
+					   $value=mb_convert_encoding($value,'UTF-8', 'ISO-8859-1');
 				}
-
 				$v=explode('|',$value);
 				if ($v[0]=="H" or $v[0]=="L") continue;
 				echo "<tr><td>".$v[1]."</td><td>".$v[2]."</td><td>";

--- a/www/htdocs/mysite/cancelreservation.php
+++ b/www/htdocs/mysite/cancelreservation.php
@@ -124,7 +124,7 @@ $legend="";
 
       echo "<div><table><tr>";
       echo "<td width=180><img src='".$image."' /></td>";
-      echo "<td><h2>".utf8_encode($myresult)."</h2></td></tr><tr><td colspan=2><h3>".utf8_encode($legend)."</h3></td>";
+      echo "<td><h2>".mb_convert_encoding($myresult,'UTF-8', 'ISO-8859-1')."</h2></td></tr><tr><td colspan=2><h3>".mb_convert_encoding($legend,'UTF-8', 'ISO-8859-1')."</h3></td>";
       echo "</tr></table></div>";
 
 

--- a/www/htdocs/mysite/loanrenovation.php
+++ b/www/htdocs/mysite/loanrenovation.php
@@ -175,7 +175,7 @@ if (strlen($legend)==0) $success=true;
 
       echo "<div><table><tr>";
       echo "<td width=180><img src='".$image."' /></td>";
-      echo "<td><h2>".utf8_encode($myresult)."</h2></td></tr><tr><td colspan=2><h3>".utf8_encode($legend)."</h3></td>";
+      echo "<td><h2>".mb_convert_encoding($myresult,'UTF-8', 'ISO-8859-1')."</h2></td></tr><tr><td colspan=2><h3>".mb_convert_encoding($legend,'UTF-8', 'ISO-8859-1')."</h3></td>";
       echo "</tr></table></div>";
 
 

--- a/www/htdocs/mysite/queryobjectservice.php
+++ b/www/htdocs/mysite/queryobjectservice.php
@@ -142,7 +142,7 @@ foreach ($splittxttit as $onetit)
 if ($onetit!='') $result.=$onetit." ";
 }
 }
-echo utf8_encode($result);
+echo mb_convert_encoding($result,'UTF-8', 'ISO-8859-1');;
 }
 
 

--- a/www/htdocs/mysite/reserve.php
+++ b/www/htdocs/mysite/reserve.php
@@ -274,7 +274,7 @@ if (strlen($legend)==0) $success=true;
 
       echo "<div><table><tr>";
       echo "<td width=180><img src='".$image."' /></td>";
-      echo "<td><h2>".utf8_encode($myresult)."</h2></td></tr><tr><td colspan=2><h3>".utf8_encode($legend)."</h3></td>";
+      echo "<td><h2>".mb_convert_encoding($myresult,'UTF-8', 'ISO-8859-1')."</h2></td></tr><tr><td colspan=2><h3>".mb_convert_encoding($legend,'UTF-8', 'ISO-8859-1')."</h3></td>";
       echo "</tr></table></div>";
 
       //echo $client->request;

--- a/www/htdocs/opac/buscar_integrada.php
+++ b/www/htdocs/opac/buscar_integrada.php
@@ -365,7 +365,7 @@ foreach ($bd_list as $base=>$value){
        		else
        			$cset_db="UTF-8";
         if ($cset=="UTF-8" and $cset_db=="ANSI")
-        	$busqueda_decode[$base]=utf8_decode($busqueda);
+        	$busqueda_decode[$base]=mb_convert_encoding($busqueda,'UTF-8', 'ISO-8859-1');
         else
         	$busqueda_decode[$base]=$busqueda;
         if ($busqueda_decode[$base]=="") $busqueda_decode[$base]='$';

--- a/www/htdocs/opac/presentar_seleccion_inc.php
+++ b/www/htdocs/opac/presentar_seleccion_inc.php
@@ -5,7 +5,7 @@
 
 
 ***********************************************/
-	
+
 function DeterminarReservasActivas($db_path,$base,$lang,$msgstr,$Ctrl){
 global $arrHttp,$xWxis, $actparfolder;
 	$data="";
@@ -181,11 +181,14 @@ foreach ($list as $value){
         }
 	}
 }
+
+
+
 foreach ($seleccion as $base=>$value){
     echo "<hr style=\"border: 5px solid #cccccc;border-radius: 5px;\">";
 	echo "<div><h3>";
 	if (file_exists($db_path.$base."/pfts/dcxml.pft") or file_exists($db_path.$base."/pfts/marcxml.pft")){
-		echo "<a class='bt' href=javascript:SendToXML(\"".$xml_base[$base]."\")>XML</a>&nbsp; &nbsp;";
+		echo "<a class='btn btn-primary' href=javascript:SendToXML(\"".$xml_base[$base]."\")>XML</a>&nbsp; &nbsp;";
 	}
 	echo $bd_list[$base]["descripcion"]." ($base)</h3></div><br><br>";
 	$lista_mfn="";

--- a/www/htdocs/opac/sendtoxml.php
+++ b/www/htdocs/opac/sendtoxml.php
@@ -15,19 +15,19 @@ function wxisLlamar($base,$query,$IsisScript){
 	return $contenido;
 }
 
-if (isset($_REQUEST["sendto"]) and trim($_REQUEST["sendto"])!="")
-	$_REQUEST["cookie"]=$_REQUEST["sendto"] ;
+//if (isset($_REQUEST["sendto"]) and trim($_REQUEST["sendto"])!="")
+	//$_REQUEST["cookie"]=$_REQUEST["sendto"] ;
 $list=explode("|",$_REQUEST["cookie"]);
 $seleccion=array();
 $primeravez="S";
 
 
 
-$filename="abcdOpac_xml.";
+$filename="abcdOpac.xml";
 header('Content-Type: text/xml; charset=".$charset."');
 header("Expires: 0");
 header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-//header("content-disposition: attachment;filename=$filename");
+header("content-disposition: attachment;filename=$filename");
 $ix=0;
 $contador=0;
 $control_entrada=0;
@@ -41,6 +41,12 @@ foreach ($list as $value){
 
 $xml_head="Y";
 $lista_mfn="";
+
+if ($xml_head=="Y"){
+	echo "<?xml version=\"1.0\"?> \n";
+	$xml_head="N";
+}
+
 foreach ($seleccion as $base=>$value){
 	$lists_mfn="";
 	foreach ($value as $mfn){
@@ -67,15 +73,12 @@ $query = "&base=".$base."&cipar=$db_path"."par/$base".".par&Mfn=$lista_mfn&Forma
 $resultado=wxisLlamar($base,$query,$xWxis."opac/imprime_sel.xis");
 	//echo '<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">'."\n";
 	//echo "<!DOCTYPE dublinCore PUBLIC '-//OCLC//DTD Dublin core v.1//EN'> \n";
-if ($xml_head=="Y"){
-	echo "<?xml version=\"1.0\"?> \n";
-	$xml_head="N";
-}
+
 echo $encabezado;
 foreach($resultado as $value)  {
 	$value=trim($value);
 	if (substr($value,0,8)=="[TOTAL:]") continue;
-	$value=utf8_encode($value);
+	$value=mb_convert_encoding($value,'UTF-8', 'ISO-8859-1');
 	echo str_replace('&','&amp;',$value);
 }
 echo $pie;


### PR DESCRIPTION
After some reports on recent installations using Xampp with PHP 8.2, it was necessary to replace utf8_decode() with mb_convert_encoding() as suggested by the post: https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated.

![unnamed](https://user-images.githubusercontent.com/20482054/233758628-c3d12bb3-9f91-479f-9b03-a2356e3fac8d.png)

