### PR TITLE
Update captcha_get_font.php

### DIFF
--- a/www/htdocs/central/common/captcha_get_font.php
+++ b/www/htdocs/central/common/captcha_get_font.php
@@ -5,6 +5,7 @@
 ** Shows also an error as html if used in an html generating file (e.g. index.php)
 **
 20240602 fho4abcd Created
+20240610 fho4abcd Check also extension gd.
 */
 function captcha_font() {
 	$font=$_SERVER['DOCUMENT_ROOT'].'/assets/webfonts/first_school.ttf';
@@ -13,6 +14,11 @@ function captcha_font() {
 		echo "<div style='color:red'>".$message."</div>";
 		error_log($message);
 		die;
+	}
+	if (!extension_loaded('gd')&&!extension_loaded('gd2')) {
+		$message="Load required PHP extension 'gd' (or equivalent gd2/gd.so/....)";
+		echo "<div style='color:red'>".$message."</div>";
+		error_log($message);
 	}
 	return $font;
 }


### PR DESCRIPTION
Check explicitly for loaded extension gd.
If this check comes later the standard message is hard to find and does not directly hint to the absence of gd