### PR TITLE
Improve UTF-8 display if no database is active

### DIFF
--- a/www/htdocs/central/common/inc_nodb_lang.php
+++ b/www/htdocs/central/common/inc_nodb_lang.php
@@ -1,0 +1,59 @@
+<?php
+/*
+20250204 fho4abcd Created
+Function  : Set language variables in the case that no database is set, or not desired.
+            This is the case for several administrative scripts like translate .php
+Usage     : <?php include "../common/inc_nodb_lang.php" ?>
+** Variable:none
+** Notes  : Table $curlangcode should be replaced by reading a file (candidate bases/lang.tab)
+**        : $guesstatus and $selcharset are used in scripts that display a choice to change code
+*/
+// Get the current language code (preset by config.php)
+$lang=$_SESSION["lang"];
+// unset a possible database:encoding may be different from langauage file
+if (isset($_REQUEST["base"])) $_REQUEST["base"]="";
+$baseSelect = "";// used in inicio.php
+// Try to guess from the language code and the actual code as existed at the time this script was written
+// The future is UTF-8, but we have currently some ISO langauges
+$curlangcode["de"]="ISO-8859-1";//German
+$curlangcode["en"]="ISO-8859-1";//English
+$curlangcode["es"]="ISO-8859-1";//Spanish
+$curlangcode["fr"]="ISO-8859-1";//French
+$curlangcode["it"]="ISO-8859-1";//Italian
+$curlangcode["nl"]="ISO-8859-1";//Dutch (Nederlands)
+$curlangcode["nn"]="ISO-8859-1";//Norwegian
+$curlangcode["pt"]="ISO-8859-1";//Portuguese
+$curlangcode["sv"]="ISO-8859-1";//Swedish
+$curlangcode["am"]="UTF-8";//Amharic
+$curlangcode["ar"]="UTF-8";//Arabic
+$curlangcode["he"]="UTF-8";//Hebrew
+$curlangcode["el"]="UTF-8";//Greek
+$curlangcode["ma"]="UTF-8";//Marathi. Code should be "mr"
+$curlangcode["ru"]="UTF-8";//Russian
+$curlangcode["si"]="UTF-8";//Sinhalese
+// Take the code if present in the array
+if ( isset($curlangcode[$lang]) ) {
+    $guessstatus="lang"; // in 00: string "Language"
+    $selcharset=$curlangcode[$lang];
+} else {
+    $guessstatus="basesdef"; // in 00: "Bases default"
+    $selcharset=$charset;
+}
+// And a manual selected code overrules all guesses.
+if (isset($arrHttp["selcharset"])){
+    $guessstatus="manual"; // in 00: string "Manually set"
+    $selcharset=$arrHttp["selcharset"];
+}
+// Set the variables in such a way that the current language will be displayed correct
+$charset=$selcharset;
+$meta_encoding=$charset;
+$_SESSION["meta_encoding"]=$charset;
+if ( $charset=="UTF-8") {
+    $unicode=1;
+} else {
+    $unicode=0;
+}
+// Send characterset to the server. Note that the browser gets it via the html header.
+// This overrules the default header in config.
+header('Content-type: text/html; charset='.$charset);
+?>

--- a/www/htdocs/central/common/inicio.php
+++ b/www/htdocs/central/common/inicio.php
@@ -10,6 +10,7 @@
 2022-07-10 fho4abcd Prepare for .par file in database folder+ no password to llamar_wxis.php
 2024-05-19 fho4abcd Added alternative return script. When the standard index.php is forbidden
 2024-06-01 fho4abcd Check captcha
+2025-02-04 fho4abcd Improve UTF-8 display if no databases is selected
 */
 global $Permiso, $arrHttp,$valortag,$nombre;
 $arrHttp=Array();
@@ -395,6 +396,10 @@ if (isset($arrHttp["lang"]) and $arrHttp["lang"]!=""){
 
 }else{
 	if (!isset($_SESSION["lang"])) $_SESSION["lang"]=$lang;
+}
+
+if (!isset($arrHttp['base'])) {
+    include("../common/inc_nodb_lang.php");
 }
 include("../lang/dbadmin.php");
 include("../lang/admin.php");

--- a/www/htdocs/central/dbadmin/dirtree.php
+++ b/www/htdocs/central/dbadmin/dirtree.php
@@ -4,6 +4,7 @@
 20211215 fho4abcd Backbutton & helper by included file
 20220203 fho4abcd Typo + improve folder selection and do not screw up $arrHttp["base"]
 20220630 fho4abcd Back to Home if $arrHttp["base"] not set or lost. Loosing is easy due to the dozens of forms.Improve html
+20250204 fho4abcd Improve UTF-8 display
 */
 /*
  This program is free software; you can redistribute it and/or
@@ -196,6 +197,7 @@ if ((isset($_SESSION["permiso"]["CENTRAL_ALL"]) or
 	header("Location: ../common/error_page.php") ;
 }
 include("../config.php");
+include("../common/inc_nodb_lang.php");
 $_SESSION["root_base"]=$db_path;
 $_SESSION["dir_base"]="";
 if (isset($arrHttp["folder"])){

--- a/www/htdocs/central/dbadmin/menu_creardb.php
+++ b/www/htdocs/central/dbadmin/menu_creardb.php
@@ -2,6 +2,7 @@
 /*
 20210921 fho4abcd Button in form + inc_div-helper + sanitize html + remove unused VerificarTipo + translations
 20211216 fho4abcd Backbutton by included file
+20250204 fho4abcd Improve UTF-8 display
 */
 session_start();
 unset($_SESSION["DCIMPORT"]);
@@ -19,7 +20,7 @@ unset($_SESSION["FST"]);
 if (!isset($_SESSION["lang"]))  $_SESSION["lang"]="en";
 include("../common/get_post.php");
 include ("../config.php");
-$lang=$_SESSION["lang"];
+include("../common/inc_nodb_lang.php");
 
 
 

--- a/www/htdocs/central/dbadmin/menu_traducir.php
+++ b/www/htdocs/central/dbadmin/menu_traducir.php
@@ -5,6 +5,7 @@
 20210829 fho4abcd Added missing importdoc compare+replace componente by table
 20211216 fho4abcd Backbutton by included file
 20221030 fho4abcd Added translations for odds, mysite. Use moduleButton for modules
+20250204 fho4abcd Improve UTF-8 display
 */
 session_start();
 if (!isset($_SESSION["permiso"])){
@@ -13,7 +14,9 @@ if (!isset($_SESSION["permiso"])){
 if (!isset($_SESSION["lang"]))  $_SESSION["lang"]="en";
 include("../common/get_post.php");
 include ("../config.php");
-$lang=$_SESSION["lang"];
+
+include("../common/inc_nodb_lang.php");
+
 include("../lang/acquisitions.php");
 include("../lang/admin.php");
 include("../lang/dbadmin.php");

--- a/www/htdocs/central/dbadmin/reset_inventory_number.php
+++ b/www/htdocs/central/dbadmin/reset_inventory_number.php
@@ -1,6 +1,7 @@
 <?php
 /* Modifications
 20211216 fho4abcd Backbutton & helper by included file. Improve html
+20250204 fho4abcd Improve UTF-8 display
 */
 session_start();
 if (!isset($_SESSION["permiso"])){
@@ -13,7 +14,7 @@ if (!isset($_SESSION["permiso"])){
 if (!isset($_SESSION["lang"]))  $_SESSION["lang"]="en";
 include("../common/get_post.php");
 include("../config.php");
-$lang=$_SESSION["lang"];
+include("../common/inc_nodb_lang.php");
 include("../lang/admin.php");
 include("../lang/dbadmin.php");
 include("../lang/acquisitions.php");

--- a/www/htdocs/central/settings/conf_abcd.php
+++ b/www/htdocs/central/settings/conf_abcd.php
@@ -3,6 +3,7 @@
 20210615 fho4abcd Removed opac configuration.Not working and not in line with wiki OPAC-ABCD Configuration Tutorial
 20210615 fho4abcd Improve html, cleanup code, lineends
 20211216 fho4abcd Backbutton by included file
+20250204 fho4abcd Improve UTF-8 display
 */
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -19,6 +20,7 @@ if (!isset($_SESSION["lang"]))  $_SESSION["lang"]="en";
 $lang=$_SESSION["lang"];
 include("../common/get_post.php");
 include("../config.php");
+include("../common/inc_nodb_lang.php");
 
 // ARCHIVOS DE LENGUAJE
 include("../lang/admin.php");


### PR DESCRIPTION
The UTF-8 language files were correctly shown when an UTF-8 database was active. If no such databases is active (the Administration scripts like Translate Messages) were showing garbled text. This is for a major part improved