### PR TITLE
Reduced error messages

### DIFF
--- a/www/htdocs/central/common/footer.php
+++ b/www/htdocs/central/common/footer.php
@@ -60,7 +60,7 @@ include "css_settings.php";
         } else {
             $text2 = "TEXT2";
         }
-		$versioninfo=$msgstr["version"].": v2.2.0-beta-1 + ... &rarr; 2025-03-16";
+		$versioninfo=$msgstr["version"].": v2.2.0-beta-1 + ... &rarr; 2025-03-21";
 ?>
         <span><small><a href="http://www.abcdwiki.net/" target="_blank">Wiki</a>  - <?php echo $versioninfo?> </small></span>
     </div>

--- a/www/htdocs/central/copies/copies_add.php
+++ b/www/htdocs/central/copies/copies_add.php
@@ -207,6 +207,18 @@ if ($err_copies=="Y"){
 	die;
 }
 
+	//GET LAST CONTROL NUMBER
+	$archivo = $db_path . $arrHttp["base"] . "/data/control_number.cn";
+	if (!file_exists($archivo)) {
+		$fp = fopen($archivo, "w");
+		$res = fwrite($fp, "");
+		fclose($fp);
+	} else {
+		$fp = file($archivo);
+		$last_cn = implode("", $fp);
+		$last_cn = trim($last_cn); // Garante que não há espaços em branco extras
+	}
+
 ?>
 	<div class="searchBox">
 		<label for="addCopies">
@@ -227,12 +239,18 @@ if ($err_copies=="Y"){
 
 	<div class="formContent" id="formContent">
 <?php
+
+
+
 $arrHttp["cipar"]="copies.par";
 $fmt_test="S";
 $arrHttp["wks"]="new.fmt";
 $wks_avail["new"]=1;
 $valortag[10]=$db_addto;
 $arrHttp["db_addto"]=$db_addto;
+
+echo "<h4>".$msgstr["cn_last_number"]." ".$last_cn."</h4>";
+
 include("../dataentry/plantilladeingreso.php");
 ConstruyeWorksheetFmt();
 include("../dataentry/dibujarhojaentrada.php");

--- a/www/htdocs/central/copies/copies_add_add.php
+++ b/www/htdocs/central/copies/copies_add_add.php
@@ -1,234 +1,276 @@
 <?php
+
 /*
 20220424 rogercgui add backbutton and inc-helper
+20250321 rogercgui Improved addition of automatic copies. The spreadsheet now signals to the cataloguer the largest number of inventory used. It also correctly records the highest number used in the control_number.cn file.
 */
 
 session_start();
-if (!isset($_SESSION["permiso"])){
-	header("Location: ../common/error_page.php") ;
+if (!isset($_SESSION["permiso"])) {
+    header("Location: ../common/error_page.php");
 }
-if (!isset($_SESSION["lang"]))  $_SESSION["lang"]="en";
+if (!isset($_SESSION["lang"]))  $_SESSION["lang"] = "en";
 include("../common/get_post.php");
 include("../config.php");
-$lang=$_SESSION["lang"];
+$lang = $_SESSION["lang"];
 
 include("../lang/acquisitions.php");
 include("../lang/admin.php");
+
 //foreach ($arrHttp as $var=>$value)  echo "$var=$value<br>";
 //die;
+
 include("../common/abcd_ref.php");
 include("../common/header.php");
-echo "<body>\n";
 
 ?>
+
 <div class="sectionInfo">
-	<div class="breadcrumb">
-		<?php echo $arrHttp["base"].": ".$msgstr["createcopies"]?>
-	</div>
-	<div class="actions">
+    <div class="breadcrumb">
+        <?php echo $arrHttp["base"] . ": " . $msgstr["createcopies"]; ?>
+    </div>
+    <div class="actions">
 
-		<?php 
-		unset ($arrHttp["base"]);
-		$backtoscript="javascript:top.Menu('same')";
-		include "../common/inc_back.php";
-		?>
+        <?php
+        unset($arrHttp["base"]);
+        $backtoscript = "javascript:top.Menu('same')";
+        include "../common/inc_back.php";
+        ?>
 
-	</div>
-	<div class="spacer">&#160;</div>
+    </div>
+    <div class="spacer">&#160;</div>
 </div>
 
-
-<?php 
-
-$ayuda="/acquisitions/copies_create.html";
+<?php
+$ayuda = "/acquisitions/copies_create.html";
 include "../common/inc_div-helper.php" ?>
 
-
 <div class="middle form">
-			<div class="formContent">
-<?php
-$arrHttp["Opcion"]="ver";
-$arrHttp["database"]=$arrHttp["tag10"];
-$arrHttp["objectid"]=$arrHttp["tag1"];
-// se lee la FDT para conseguir la etiqueta del campo donde se coloca la numeración automática
+    <div class="formContent">
 
-LeerFst($arrHttp["database"]);
+        <?php
+        $arrHttp["Opcion"] = "ver";
+        $arrHttp["database"] = $arrHttp["tag10"];
+        $arrHttp["objectid"] = $arrHttp["tag1"];
 
-// Se lee la base de datos catalográfica para determinar si el objeto ha sido ingresado
-$Formato=$db_path.$arrHttp["database"]."/pfts/".$_SESSION["lang"]."/".$arrHttp["database"].".pft" ;
-if (!file_exists($Formato)) $Formato=$db_path.$arrHttp["database"]."/pfts/".$lang_db."/".$arrHttp["database"].".pft" ;
-$Formato="@$Formato,/";
-$Expresion="$pref_ctl".$arrHttp["objectid"];
-$query = "&base=".$arrHttp["database"]."&cipar=$db_path"."par/".$arrHttp["database"].".par"."&Expresion=$Expresion&Formato=$Formato&Opcion=buscar";
-$IsisScript=$xWxis."imprime.xis";
-include("../common/wxis_llamar.php");
-$cont_database=implode('',$contenido);
-if (trim($cont_database)=="") {
-	echo "<h4>".$arrHttp["objectid"].": ".$msgstr["objnoex"]."</h4>";
-	echo "\n<script>top.toolbarEnabled=\"\"</script>\n";
-	die;
-}
-$cont_database=$contenido;
-if (isset($arrHttp["copies"])) echo "<br>".$msgstr["copies_no"].": ".$arrHttp["copies"];
+        // Read the FDT to get the label of the field where the automatic numbering is placed.
 
-$Mfn="";
-if (isset($arrHttp["tag30"])  and !isset($arrHttp["copies"])){
-	$inven=explode("\n",$arrHttp["tag30"]);
-	unset($arrHttp["tag30"]);
-	foreach ($inven as $cn) {
-		if (trim($cn)!="")
-			CrearCopia(trim($cn),$max_inventory_length);
-	}
-}else{
-	for ($ix=1;$ix<=$arrHttp["copies"];$ix++ ){
-		echo "<hr>";
-		if (isset($arrHttp["tag30"])){
-			if ($ix==1)
-				$cn=$arrHttp["tag30"];
-			else
-				$cn=$cn+1;
-		}else{
-			$cn=ProximoNumero("copies");   // GENERATE THE INVENTORY NUMBER
-		}
-		CrearCopia($cn,$max_inventory_length);
-	}
-}
+        LeerFst($arrHttp["database"]);
 
-echo "<p>";
-/*foreach ($cont_database as $value){
-	$value=trim($value);
-	if (trim($value)!=""){
-		if (substr($value,0,6)=='$$REF:'){
-			   echo ABCD_Ref($value,"");
-		}else{
-			echo $value;
-		}
-	}
-}
-*/
-echo "</div></div>";
-include("../common/footer.php");
-echo "</body></html>";
-echo "\n<script>top.toolbarEnabled=\"\"</script>\n";
+        // Read the catalog database to determine whether the object has been added.
+        $Formato = $db_path . $arrHttp["database"] . "/pfts/" . $_SESSION["lang"] . "/" . $arrHttp["database"] . ".pft";
 
-//=================================================================
+        if (!file_exists($Formato)) $Formato = $db_path . $arrHttp["database"] . "/pfts/" . $lang_db . "/" . $arrHttp["database"] . ".pft";
+        $Formato = "@$Formato,/";
+        $Expresion = "$pref_ctl" . $arrHttp["objectid"];
+        $query = "&base=" . $arrHttp["database"] . "&cipar=$db_path" . "par/" . $arrHttp["database"] . ".par" . "&Expresion=$Expresion&Formato=$Formato&Opcion=buscar";
+        $IsisScript = $xWxis . "imprime.xis";
+        include("../common/wxis_llamar.php");
+        $cont_database = implode('', $contenido);
 
-function CrearCopia($cn,$max_inventory_length){
-global $msgstr,$arrHttp,$xWxis,$Wxis,$wxisUrl,$db_path;
-	$Mfn="" ;
-	$cn=str_pad($cn, $max_inventory_length, '0', STR_PAD_LEFT);
-	echo "<br>".$msgstr["createcopies"].": ";
-	echo $msgstr["inventory"].": $cn";
-	// Se verifica si ese número de inventario no existe
-	$res=BuscarCopias($cn);
-	if ($res>0){
-		echo "<font color=red> &nbsp;".$msgstr["invdup"]."</font>";
-	}else{
-		$ValorCapturado="";
-		foreach ($arrHttp as $var=>$value){
-			if (substr($var,0,3)=="tag"){
-				$tag=trim(substr($var,3));
-				if ($tag!=30) $ValorCapturado.="<".$tag." 0>".$value."</".$tag.">";
-			}
-		}
-		$ValorCapturado.="<30 0>".$cn."</30>";
-		$ValorCapturado=urlencode($ValorCapturado);
-		$IsisScript=$xWxis."actualizar.xis";
-		$query = "&base=copies&cipar=$db_path"."par/copies.par&login=".$_SESSION["login"]."&Mfn=New&Opcion=crear&ValorCapturado=".$ValorCapturado;
-		include("../common/wxis_llamar.php");
-		foreach ($contenido as $linea){
-			if (substr($linea,0,4)=="MFN:") {
-				echo " &nbsp; Mfn: <a href=../dataentry/show.php?base=copies&Mfn=".trim(substr($linea,4))." target=_blank>".trim(substr($linea,4))."</a>";
-	    		$Mfn.=trim(substr($linea,4))."|";
-			}else{
-				if (trim($linea!="")) echo $linea."\n";
-			}
-		}
-   	}
+        if (trim($cont_database) == "") {
+            echo "<h4>" . $arrHttp["objectid"] . ": " . $msgstr["objnoex"] . "</h4>";
+            echo "\n<script>top.toolbarEnabled=\"\"</script>\n";
+            die;
+        }
+        $cont_database = $contenido;
+        if (isset($arrHttp["copies"])) echo "<br>" . $msgstr["copies_no"] . ": " . $arrHttp["copies"];
 
-}
+        $Mfn = "";
+        if (isset($arrHttp["tag30"])  and !isset($arrHttp["copies"])) {
+            $inven = explode("\n", $arrHttp["tag30"]);
+            unset($arrHttp["tag30"]);
+            foreach ($inven as $cn) {
+                if (trim($cn) != "")
+                    CrearCopia(trim($cn), $max_inventory_length);
+            }
+        } else {
 
-function ProximoNumero($base){
-global $db_path;
-	$archivo=$db_path.$base."/data/control_number.cn";
-	if (!file_exists($archivo)){
-		echo "<h2>Missign file $base/data/control_number.cn</h2>";
-		return 0;
-	}
-	$perms=fileperms($archivo);
+            $ultimo_cn = 0; // Initializes the variable to store the last used CN.
+            for ($ix = 1; $ix <= $arrHttp["copies"]; $ix++) {
+                echo "<hr>";
+                if (isset($arrHttp["tag30"])) {
+                    if ($ix == 1) {
+                        $cn = $arrHttp["tag30"];
+                    } else {
+                        $cn = $cn + 1;
+                    }
+                } else {
+                    $cn = ProximoNumero("copies", "ler") + 1; // Read and increment
+                }
+                $cn = str_pad($cn, $max_inventory_length, '0', STR_PAD_LEFT); // Format with leading zeros
+                CrearCopia($cn, $max_inventory_length);
+                $ultimo_cn = $cn; // Stores the last used CN
+            }
+            $write_result = ProximoNumero($ultimo_cn, "escrever"); // Update the file with the latest number (outside the loop)
+            if ($write_result === 1) {
+                echo "<br>".$msgstr['cn_fwrite_success']." " . $ultimo_cn;
+            } else {
+                echo "<br><font color='red'>".$msgstr['cn_fwrite_error']."</font>";
+            }
+        }
 
-	if (is_writable($archivo)){
-	//se protege el archivo con el número secuencial
-		chmod($archivo,0555);
-	// se lee el último número asignado y se le agrega 1
-		$fp=file($archivo);
-		$cn=implode("",$fp);
-		$cn=$cn+1;
-	// se remueve el archivo .bak y se renombre el archivo .cn a .bak
-		if (file_exists($db_path.$base."/data/control_number.bak"))
-			unlink($db_path.$base."/data/control_number.bak");
-		$res=rename($archivo,$db_path.$base."/data/control_number.bak");
-		chmod($db_path.$base."/data/control_number.bak",0666);
-		$fp=fopen($archivo,"w");
-	    fwrite($fp,$cn);
-	    fclose($fp);
-	    chmod($archivo,0666);
-	    return $cn;
-	}
-}
+        /*foreach ($cont_database as $value){
+            $value=trim($value);
+            if (trim($value)!=""){
+                if (substr($value,0,6)=='$$REF:'){
+                    echo ABCD_Ref($value,"");
+                } else {
+                    echo $value;
+                }
+            }
+        }*/
 
-function BuscarCopias($inventario){
-global $xWxis,$db_path,$wxisUrl,$Wxis;
-	if ($inventario!=""){
-		$Prefijo="IN_".$inventario;
-	}else{
-		$Prefijo='ORDER_'.$order.'_'.$suggestion.'_'.$bidding;
-	}
-	$IsisScript= $xWxis."ifp.xis";
-	$query = "&base=copies&cipar=$db_path"."par/copies.par&Opcion=diccionario&prefijo=$Prefijo&campo=1";
-	$contenido=array();
-	include("../common/wxis_llamar.php");
-	foreach ($contenido as $linea){
-		if (trim($linea)!=""){
-			$pre=trim(substr($linea,0,strlen($Prefijo)));
-			if ($pre==$Prefijo){
-				$l=explode('|',$linea);
-				return $l[1];
-				break;
-			}
-		}
-	}
-	return 0;
-}
+        echo "</div></div>";
+        include("../common/footer.php");
+        echo "</body></html>";
+        echo "\n<script>top.toolbarEnabled=\"\"</script>\n";
 
-function LeerFst($base){
-global $tag_ctl,$pref_ctl,$arrHttp,$db_path,$AI,$lang_db,$msgstr,$error;
-// GET THE FST TO FIND THE CONTROL NUMBER OF A BIBLIOGRAPHIC DATABASE
-	$archivo=$db_path.$base."/data/".$base.".fst";
-	if (!file_exists($archivo)){
-		echo "missing file ".$base."/data/".$base.".fst";
-		die;
-	}
-	$fp=file($archivo);
-	$tag_ctl="";
-	$pref_ctl="CN_";
-	foreach ($fp as $linea){
-		$linea=trim($linea);
-		$ix=strpos($linea,"\"CN_\"");
-		if ($ix===false){
-			$ix=strpos($linea,'|CN_|');
-		}
-		if ($ix===false){
-		}else{
-			$ix=strpos($linea," ");
-			$tag_ctl=trim(substr($linea,0,$ix));
-			break;
-		}
-	}
-	// Si no se ha definido el tag para el número de control en la fdt, se produce un error
-	if ($tag_ctl==""){
-		$error="missingctl";
-	}
+        //=================================================================
+
+        function CrearCopia($cn, $max_inventory_length) {
+            global $msgstr, $arrHttp, $xWxis, $Wxis, $wxisUrl, $db_path;
+            $Mfn = "";
+            //$cn=str_pad($cn, $max_inventory_length, '0', STR_PAD_LEFT);
+            echo "<br>" . $msgstr["createcopies"] . ": ";
+            echo $msgstr["inventory"] . ": $cn";
+            // Se verifica si ese número de inventario no existe
+            $res = BuscarCopias($cn);
+            if ($res > 0) {
+                echo "<font color=red> &nbsp;" . $msgstr["invdup"] . "</font>";
+            } else {
+                $ValorCapturado = "";
+                foreach ($arrHttp as $var => $value) {
+                    if (substr($var, 0, 3) == "tag") {
+                        $tag = trim(substr($var, 3));
+                        if ($tag != 30) $ValorCapturado .= "<" . $tag . " 0>" . $value . "</" . $tag . ">";
+                    }
+                }
+                $ValorCapturado .= "<30 0>" . $cn . "</30>";
+                $ValorCapturado = urlencode($ValorCapturado);
+                $IsisScript = $xWxis . "actualizar.xis";
+                $query = "&base=copies&cipar=$db_path" . "par/copies.par&login=" . $_SESSION["login"] . "&Mfn=New&Opcion=crear&ValorCapturado=" . $ValorCapturado;
+                include("../common/wxis_llamar.php");
+                foreach ($contenido as $linea) {
+                    if (substr($linea, 0, 4) == "MFN:") {
+                        echo " &nbsp; Mfn: <a href=../dataentry/show.php?base=copies&Mfn=" . trim(substr($linea, 4)) . " target=_blank>" . trim(substr($linea, 4)) . "</a>";
+                        $Mfn .= trim(substr($linea, 4)) . "|";
+                    } else {
+                        if (trim($linea != "")) echo $linea . "\n";
+                    }
+                }
+            }
+        }
+
+function ProximoNumero($base, $modo = "ler") {
+    global $db_path;
+    $arquivo = $db_path . "copies/data/control_number.cn";
+
+    error_log("ProximoNumero called based on: " . $base . ", modo: " . $modo);
+    error_log("File path: " . $arquivo); // Log do caminho
+
+    if (!file_exists($arquivo)) {
+        error_log("Erro: File control_number.cn not found in: " . $arquivo);
+        return 0;
+    }
+
+    $fp = fopen($arquivo, "c+");
+    if (!$fp) {
+        error_log("Erro: Could not open file: " . $arquivo);
+        return 0;
+    }
+
+    if ($modo == "ler") {
+        $cn = trim(fgets($fp));
+        $cn = $cn === "" ? 0 : intval($cn);
+        fclose($fp);
+        error_log("ProximoNumero reading CN: " . $cn);
+        return $cn;
+    } elseif ($modo == "escrever" && is_numeric($base)) {
+        $locked = flock($fp, LOCK_EX);
+        if (!$locked) {
+            error_log("Erro: Could not obtain lock on file: " . $arquivo);
+            fclose($fp);
+            return 0;
+        }
+        rewind($fp);
+        $write_result = fwrite($fp, strval($base));
+        if ($write_result === FALSE) {
+            error_log("Erro: Could not write to file: " . $arquivo);
+            flock($fp, LOCK_UN);
+            fclose($fp);
+            fclose($fp);
+            return 0;
+        }
+        fflush($fp);
+        $unlocked = flock($fp, LOCK_UN);
+        if (!$unlocked) {
+            error_log("Erro: Could not release file lock: " . $arquivo);
+        }
+        fclose($fp);
+        error_log("ProximoNumero he wrote CN: " . $base);
+        return 1;
+    } else {
+        fclose($fp);
+        return 0;
+    }
 }
 
-?>
+        function BuscarCopias($inventario)
+        {
+            global $xWxis, $db_path, $wxisUrl, $Wxis;
+
+            if ($inventario != "") {
+                $Prefijo = "IN_" . $inventario;
+            } else {
+                $Prefijo = 'ORDER_' . $order . '_' . $suggestion . '_' . $bidding;
+            }
+
+            $IsisScript = $xWxis . "ifp.xis";
+            $query = "&base=copies&cipar=$db_path" . "par/copies.par&Opcion=diccionario&prefijo=$Prefijo&campo=1";
+            $contenido = array();
+            include("../common/wxis_llamar.php");
+            foreach ($contenido as $linea) {
+                if (trim($linea) != "") {
+                    $pre = trim(substr($linea, 0, strlen($Prefijo)));
+                    if ($pre == $Prefijo) {
+                        $l = explode('|', $linea);
+                        return $l[1];
+                        break;
+                    }
+                }
+            }
+            return 0;
+        }
+
+        function LeerFst($base)
+        {
+            global $tag_ctl, $pref_ctl, $arrHttp, $db_path, $AI, $lang_db, $msgstr, $error;
+            // GET THE FST TO FIND THE CONTROL NUMBER OF A BIBLIOGRAPHIC DATABASE
+            $archivo = $db_path . $base . "/data/" . $base . ".fst";
+            if (!file_exists($archivo)) {
+                echo "missing file " . $base . "/data/" . $base . ".fst";
+                die;
+            }
+            $fp = file($archivo);
+            $tag_ctl = "";
+            $pref_ctl = "CN_";
+            foreach ($fp as $linea) {
+                $linea = trim($linea);
+                $ix = strpos($linea, "\"CN_\"");
+                if ($ix === false) {
+                    $ix = strpos($linea, '|CN_|');
+                }
+                if ($ix === false) {
+                } else {
+                    $ix = strpos($linea, " ");
+                    $tag_ctl = trim(substr($linea, 0, $ix));
+                    break;
+                }
+            }
+            // Si no se ha definido el tag para el número de control en la fdt, se produce un error
+            if ($tag_ctl == "") {
+                $error = "missingctl";
+            }
+        }
+        ?>

--- a/www/htdocs/central/dataentry/dibujarhojaentrada.php
+++ b/www/htdocs/central/dataentry/dibujarhojaentrada.php
@@ -1032,15 +1032,35 @@ global $ixicampo,$valortag,$arrHttp,$Path,$Marc,$db_path,$lang_db,$msgstr,$MD5,$
 				}
 				if ($maxlength!=0)
 						echo "<a style=\"text-decoration:none\" onMouseover=\"ddrivetip(document.forma1.tag".$tag.".value,'linen',300 )\"; onMouseout=\"hideddrivetip()\"; onclick=\"hideddrivetip()\">";
-	   			echo '<input type="'.$it.'" name=tag'.$tag.' id="tag'.$tag.'" size="'.$len.'"';
-	   			if ($maxlength>0){
-	   				echo ' maxlength="'.$maxlength.'" "';
-	   			}
-	   			echo ' value="'.$campo.'" '.$arrow.'>';
+				if ($tipo!="AI") {
+					echo '<input type="'.$it.'" name=tag'.$tag.' id="tag'.$tag.'" size="'.$len.'"';
+					if ($maxlength>0){
+						echo ' maxlength="'.$maxlength.'" "';
+					}
+					echo ' value="'.$campo.'" '.$arrow.'>';
+				}
 	   			if ($maxlength!=0)
 	   				echo "</a>";
 
 	   			if ($tipo=="AI") {
+				//GET LAST CONTROL NUMBER
+						$archivo=$db_path.$arrHttp["base"]."/data/control_number.cn";
+						if (!file_exists($archivo)){
+							$fp=fopen($archivo,"w");
+							$res=fwrite($fp,"");
+							fclose($fp);
+						}else{
+							$fp=file($archivo);
+							$last_cn=implode("",$fp)+1;
+						}
+
+					echo '<input type="'.$it.'" name=tag'.$tag.' id="tag'.$tag.'" size="'.$len.'"';
+					if ($maxlength>0){
+						echo ' maxlength="'.$maxlength.'" "';
+					}
+					echo ' placeholder="'.$last_cn.'" value="'.$campo.'" '.$arrow.'>';
+
+
 	   				if (isset($_SESSION["permiso"]["CENTRAL_RESETLCN"]) or isset($_SESSION["permiso"]["CENTRAL_ALL"])  or isset($_SESSION["permiso"][$arrHttp["base"]."_CENTRAL_ALL"]) or isset($_SESSION["permiso"][$arrHttp["base"]."_CENTRAL_RESETLCN"]) or isset($_SESSION["permiso"]["ACQ_ALL"]) or isset($_SESSION["permiso"]["ACQ_RESETCN"])){
 	   					echo "\n <a class='bt-fdt-green' href='javascript:ChangeSeq($tag,\"$pref\")'><i class=\"fas fa-plus\"></i> ".$msgstr["assign"]."</a> &nbsp; ";
 	   					echo "\n<a class='bt-fdt-help' href='../documentacion/ayuda.php?help=".$_SESSION["lang"]."/autoincrement.html' target=_blank><i class=\"far fa-life-ring\"></i> ".$msgstr["help"]."</a>&nbsp; &nbsp;";

--- a/www/htdocs/central/dbadmin/assign_control_number.php
+++ b/www/htdocs/central/dbadmin/assign_control_number.php
@@ -1,11 +1,4 @@
 <?php
-/* Modifications
-20210613 fho4abcd remove password, lineends
-20211215 fho4abcd Backbutton by & helper by included file
-20220203 fho4abcd Cleanup code&html+translation+make it work after reinvoke
-20220303 rogercgui Corrected the absence of the variable in the function "EnviarFormaCN"
-20220321 fho4abcd Reinstalled absence of variable. Use new par variable
-*/
 session_start();
 if (!isset($_SESSION["permiso"])){
 	header("Location: ../common/error_page.php") ;
@@ -13,15 +6,36 @@ if (!isset($_SESSION["permiso"])){
 //error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING);
 include("../common/get_post.php");
 include ("../config.php");
-include("../lang/admin.php");
+include ("../lang/admin.php");
 include("../lang/soporte.php");
-include("../lang/dbadmin.php");
+include ("../lang/dbadmin.php");
 
+
+
+
+
+function LeerArchivos($Dir,$Ext){
+// se leen los archivos con la extensión .pft
+$the_array = Array();
+$handle = opendir($Dir);
+while (false !== ($file = readdir($handle))) {
+   if ($file != "." && $file != "..") {
+   		if(is_file($Dir."/".$file))
+		   if (substr($file,strlen($file)-4,4)==".".$Ext) $the_array[]=$file;
+   }
+}
+closedir($handle);
+return $the_array;
+}
 
 // ==================================================================================================
 // INICIO DEL PROGRAMA
 // ==================================================================================================
+
 //
+
+
+
 //foreach ($arrHttp as $var=>$value) echo "$var=$value<br>";
 
 if (isset($arrHttp["encabezado"]))
@@ -32,7 +46,7 @@ else {
 
 //GET THE MAX MFN
 $IsisScript=$xWxis."administrar.xis";
-$query = "&base=".$base . "&cipar=$db_path".$actparfolder.$base.".par&Opcion=status";
+$query = "&base=".$arrHttp["base"] . "&cipar=$db_path".$actparfolder.$arrHttp["base"].".par&Opcion=status";
 
 include("../common/wxis_llamar.php");
 $ix=-1;
@@ -46,9 +60,16 @@ foreach($contenido as $linea) {
 	  	}
 	}
 }
+?>
 
+
+<script>
+Maxmfn=<?php echo $tag["MAXMFN"];?>;
+</script>
+
+<?php
 //GET LAST CONTROL NUMBER
-$archivo=$db_path.$base."/data/control_number.cn";
+$archivo=$db_path.$arrHttp["base"]."/data/control_number.cn";
 if (!file_exists($archivo)){
 	$fp=fopen($archivo,"w");
 	$res=fwrite($fp,"");
@@ -60,11 +81,10 @@ if (!file_exists($archivo)){
 
 include("../common/header.php");
 ?>
-<body>
 <script language="JavaScript" type="text/javascript" src="../dataentry/js/lr_trim.js"></script>
 <script language="JavaScript" type="text/javascript" src="../dataentry/js/selectbox.js"></script>
 
-<script language=javascript>
+<script language="javascript">
 
 function BorrarRango(){
 	document.cnFrm.Mfn.value=''
@@ -72,9 +92,9 @@ function BorrarRango(){
 }
 
 function EnviarFormaCN(vp){
-	de=Trim(document.cnFrm.Mfn.value)
-  	a=Trim(document.cnFrm.to.value)
-  	Maxmfn=<?php echo $tag["MAXMFN"];?>
+	de=Trim(document.cnFrm.Mfn.value);
+  	a=Trim(document.cnFrm.to.value);
+  	Maxmfn=<?php echo $tag["MAXMFN"];?>;
   	if (de!="" || a!="") {
   		Se=""
 		var strValidChars = "0123456789";
@@ -105,6 +125,7 @@ function EnviarFormaCN(vp){
 }
 
 </script>
+
 <?php
 if (isset($arrHttp["encabezado"])){
 	include("../common/institutional_info.php");
@@ -112,7 +133,7 @@ if (isset($arrHttp["encabezado"])){
 ?>
 <div class="sectionInfo">
 	<div class="breadcrumb">
-    <?php echo $msgstr["assigncn"].": ".$base?>
+    <?php echo $msgstr["assigncn"].": ".$arrHttp["base"]?>
 	</div>
 	<div class="actions">
     <?php
@@ -120,8 +141,8 @@ if (isset($arrHttp["encabezado"])){
 	if (isset($arrHttp["encabezado"])){
 		if (isset($_SESSION["permiso"]["CENTRAL_ALL"]) or
             isset($_SESSION["permiso"]["CENTRAL_MODIFYDEF"]) or
-            isset($_SESSION["permiso"][$base."_CENTRAL_MODIFYDEF"]) or
-            isset($_SESSION["permiso"][$base."_CENTRAL_ALL"])){
+            isset($_SESSION["permiso"][$arrHttp["base"]."_CENTRAL_MODIFYDEF"]) or
+            isset($_SESSION["permiso"][$arrHttp["base"]."_CENTRAL_ALL"])){
             $backtoscript="../dbadmin/menu_mantenimiento.php";
 		}else{
             $backtoscript="../common/inicio.php";
@@ -131,77 +152,71 @@ if (isset($arrHttp["encabezado"])){
     </div>
     <div class="spacer">&#160;</div>
 </div>
+
 <?php include "../common/inc_div-helper.php" ?>
 <div class="middle form">
 <div class="formContent">
+
+	<h3><?php echo $msgstr["assigncn"];?></h3>
+
+    <form name="cnFrm" method="post" action="assign_control_number_ex.php" onsubmit="Javascript:return false">
+    <input type="hidden" name="encabezado" value="s">
+    <input type="hidden" name="base" value="<?php echo $arrHttp["base"]?>">
+    <input type="hidden" name="cipar" value="<?php echo $arrHttp["base"]?>.par">
+
+	<p><?php echo $msgstr["r_recsel"]?>
+
+	<b><?php echo $msgstr["r_mfnr"]?>:</b></p>
+	
+	<label><?php echo $msgstr["r_desde"];?></label>
+		<input type="text" name="Mfn" size="10" value="<?php if (isset($arrHttp["from"])) echo $arrHttp["from"]; else echo "1";?>"> 
+	
 <?php
-echo "<center><h3>".$msgstr["assigncn"]."</h3></center>";
-?>
-    <form name=cnFrm method=post action=assign_control_number_ex.php onsubmit="Javascript:return false">
-    <input type=hidden name=encabezado value=s>
-    <input type=hidden name=base value=<?php echo $base?>>
-    <input type=hidden name=cipar value=<?php echo $base?>.par>
-	<table width=100% cellpadding=5>
-	<tr>
-		<td colspan=2 align=center height=1 bgcolor=#eeeeee><?php echo $msgstr["r_recsel"]?></td>
-	<tr>
-		<td  align=center colspan=2><strong><?php echo $msgstr["r_mfnr"]?></strong>: &nbsp; &nbsp; &nbsp;
-		<?php echo $msgstr["r_desde"].": <input type=text name=Mfn size=10 value=";
-		if (isset($arrHttp["from"]))
-			echo $arrHttp["from"];
-		else
-			echo "1";
-		echo ">&nbsp; &nbsp; &nbsp; &nbsp;";
-		echo $msgstr["r_hasta"].": <input type=text name=to size=10 value='";
-		if (isset($arrHttp["to"])){
-			$count=$arrHttp["to"]-$arrHttp["from"]-1;
-			$count= $arrHttp["to"]+$count-1;
-			if ($count>$tag["MAXMFN"])
-				echo $tag["MAXMFN"];
-			else
-				echo $count;
+	if (isset($arrHttp["to"])) { 
+		$count=$arrHttp["to"]-$arrHttp["from"]-1; 
+		$count= $arrHttp["to"]+$count-1; 
+		$to=$count;
+	if ($count>$tag["MAXMFN"]) {
+		$to=$tag["MAXMFN"]; 
+	} else {
+		$to=$count;
 		}
-		echo "'>";
-		echo "&nbsp;".$msgstr["maxmfn"].": ".$tag["MAXMFN"]
-		?>
-		&nbsp; &nbsp; &nbsp; <a href=javascript:BorrarRango() class=boton><?php echo $msgstr["borrar"]?></a>
-	</td>
-	<tr>
-		<td colspan=2 align=center>
-        <input type=submit name=enviar value="<?php echo $msgstr["send"]?>" onClick="javascript:EnviarFormaCN()">
-        <br><br>
-        <?php
-		echo $msgstr["lastcn"].": ".$last_cn."&nbsp; <a href=Javascript:Reset()>".$msgstr["resetcn"]."</a>";
-        ?>
-        </td>
-    </tr>
-</table>
+	} else {
+		$to="";
+	}
+?>
+
+	<label><?php echo $msgstr["r_hasta"];?></label>
+		<input type="text" name="to" size="10" value="<?php echo $to;?>">
+		
+	<small><?php echo $msgstr["maxmfn"].": ".$tag["MAXMFN"];?></small>
+
+	<div class="py-5">
+		<a href="javascript:BorrarRango()" class="bt bt-default">
+			<i class="fa fa-times"></i> <?php echo $msgstr["borrar"]?>
+		</a>
+
+        <button type="submit" class="bt-blue" onClick="javascript:EnviarFormaCN()" name=enviar>
+			<i class="fa fa-step-forward"></i> <?php echo $msgstr["send"]?>
+		</button> 
+		
+        <p><?php echo $msgstr["lastcn"].": ".$last_cn."&nbsp; <a href=Javascript:Reset()>".$msgstr["resetcn"];?></a></p>
+
+	</div>
 </form>
 </div>
 </div>
-<form name=reset_nc method=post action=reset_control_number.php>
-<input type=hidden name=base value=<?php echo $base?>>
-<input type=hidden name=encabezado value=s>
+
+<form name="reset_nc" method="post" action="reset_control_number.php">
+	<input type="hidden" name="base" value="<?php echo $arrHttp["base"]?>">
+	<input type="hidden" name="encabezado" value="s">
 </form>
-<script>function Reset(){
+
+<script>
+function Reset(){
 	document.reset_nc.submit()
 }
 </script>
-<?php
-include("../common/footer.php");
 
-//================= functions =============
-function LeerArchivos($Dir,$Ext){
-// se leen los archivos con la extensión .pft
-$the_array = Array();
-$handle = opendir($Dir);
-while (false !== ($file = readdir($handle))) {
-   if ($file != "." && $file != "..") {
-   		if(is_file($Dir."/".$file))
-		   if (substr($file,strlen($file)-4,4)==".".$Ext) $the_array[]=$file;
-   }
-}
-closedir($handle);
-return $the_array;
-}
-?>
+
+<?php include("../common/footer.php"); ?>

--- a/www/htdocs/central/dbadmin/assign_control_number_ex.php
+++ b/www/htdocs/central/dbadmin/assign_control_number_ex.php
@@ -105,24 +105,26 @@ if ($tag_ctl==""){
 	}
     ?>
     </table>
-	<form name=forma1 action=assign_control_number.php method=post>
-	<input type=hidden name=base value=<?php echo $arrHttp["base"]?>>
-	<input type=hidden name=from value=<?php echo $Mfn?>>
-	<input type=hidden name=to value=<?php echo $Mfn+$arrHttp["to"]-$arrHttp["Mfn"]?>>
-	<input type=hidden name=encabezado value=s>
-    <?php
-	if (($Mfn)<=$tag["MAXMFN"]){
-        ?>
-		<input type=submit name=go value=<?php echo $msgstr["continuar"]?>>
-    <?php } ?>
+
+	<form name="forma1" action="assign_control_number.php" method="post">
+		<input type="hidden" name="base" value="<?php echo $arrHttp["base"]?>">
+		<input type="hidden" name="from" value="<?php echo $Mfn?>">
+		<input type="hidden" name="to" value="<?php echo $Mfn+$arrHttp["to"]-$arrHttp["Mfn"]?>">
+		<input type="hidden" name="encabezado" value="s">
+    
+		<?php if (($Mfn)<=$tag["MAXMFN"]){ ?>
+			<input type="submit" class="bt-blue" name="go" value="<?php echo $msgstr["continuar"]?>">
+    	<?php } ?>
 	</form>
 	<?php
 }
 ?>
 </div>
 </div>
+
 <?php
 include "../common/footer.php";
+
 // =================== Functions ==============================
 function LeerFdt($base){
 global $tag_ctl,$pref_ctl,$arrHttp,$db_path,$msgstr;

--- a/www/htdocs/central/lang/00/admin.tab
+++ b/www/htdocs/central/lang/00/admin.tab
@@ -449,3 +449,6 @@ z3950_servers=servers
 z3950_tab=conversion table
 z3950_title=Title
 s_e_overview=System and environment overview
+cn_fwrite_success=File control_number.cn successfully updated with value:
+cn_fwrite_error:Error updating control_number.cn file.
+cn_last_number=Last number used:

--- a/www/htdocs/central/utilities/inc_select_gizmo.php
+++ b/www/htdocs/central/utilities/inc_select_gizmo.php
@@ -48,7 +48,7 @@ function count_gizmo(&$numgizmos) {
 	$extension="mst";
 	while ($file = readdir($handle)) {
 		$path_parts = pathinfo($file);
-		if ($path_parts['extension']==$extension || $path_parts['extension']==strtoupper($extension)) {
+	if (isset($path_parts['extension']) && in_array(strtolower($path_parts['extension']), array($extension, strtoupper($extension)))) {
 			$gizmo=$path_parts['filename'];
 			if ($gizmo!=$base && $gizmo!=strtoupper($base)){
 				$numgizmos++;


### PR DESCRIPTION
This update aims to make the processes related to the Autoincrement field clearer. 

In cataloguing: autoincrement is an automatic and increasing numbering, but in the cataloguing form it was never possible to know which number would be saved. It is now possible to visualise the number.

When adding copies: creating copies has the option to multiply, but the user was not shown the last number used, requiring manual control to avoid duplicates or number jumps. This has been corrected in this update.