### PR TITLE
Resolve bug for missing HTTP_ACCEPT_LANGUAGE

### DIFF
--- a/www/htdocs/central/common/footer.php
+++ b/www/htdocs/central/common/footer.php
@@ -60,7 +60,7 @@ include "css_settings.php";
         } else {
             $text2 = "TEXT2";
         }
-		$versioninfo=$msgstr["version"].": v2.2.0-beta-1 + ... &rarr; 2025-04-28";
+		$versioninfo=$msgstr["version"].": v2.2.0-beta-1 + ... &rarr; 2025-08-01";
 ?>
         <span><small><a href="http://www.abcdwiki.net/" target="_blank">Wiki</a>  - <?php echo $versioninfo?> </small></span>
     </div>

--- a/www/htdocs/index.php
+++ b/www/htdocs/index.php
@@ -13,6 +13,7 @@
 20230223 fho4abcd Check for existence of config.php
 20230602 fho4abcd Add captcha
 20250305 fho4abcd Use current username: makes filling login form more easy
+20250801 fho4abcd Do not rely on existence HTTP_ACCEPT_LANGUAGE: some browsers do not send it
 */
 session_start();
 $_SESSION=array();
@@ -24,7 +25,10 @@ $new_window=time();
 //foreach ($arrHttp as $var=>$value) echo "$var = $value<br>";
 
 $lang_config=$lang; // save the configured language to preset it later
-$lang = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])){
+    $lang = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+    //echo "HTTP_ACCEPT_LANGUAGE=$lang<br>";
+}
 
 if (isset($_SESSION["lang"])){
 	$arrHttp["lang"]=$_SESSION["lang"];


### PR DESCRIPTION
A user with Safari reported problems which seem to be caused by a missing element sent by that browser