### PR TITLE
Meta tag added

### DIFF
--- a/www/htdocs/central/common/header.php
+++ b/www/htdocs/central/common/header.php
@@ -6,31 +6,33 @@
 		Note that everything was and is cached
 		Note that a timestamp on css files does not prevent caching of included files
 */
-	if (isset($charset))
-	$content_charset=$charset;
-	else
-	$content_charset=$meta_encoding;
+if (isset($charset))
+	$content_charset = $charset;
+else
+	$content_charset = $meta_encoding;
 
-	if (!isset($css_name))
-		$css_name="";
-	else
-		$css_name.="/";
-	
-	$htmllang="";
-	if (isset($lang)) $htmllang=$lang;
+if (!isset($css_name))
+	$css_name = "";
+else
+	$css_name .= "/";
+
+$htmllang = "";
+if (isset($lang)) $htmllang = $lang;
 ?>
 <!DOCTYPE html>
-<html lang=<?php echo $lang;?>>
+<html lang=<?php echo $lang; ?>>
+
 <head>
-	<title>ABCD <?php if (isset($institution_name))  echo "| ".$institution_name?></title>
-	<meta name="keywords" content="" >
-	<meta name="description" content="" >
-	<meta name="robots" content="noindex" ><!-- robots.txt file is more effective -->
+	<title>ABCD <?php if (isset($institution_name))  echo "| " . $institution_name ?></title>
+	<meta name="keywords" content="">
+	<meta name="description" content="">
+	<meta name="robots" content="noindex"><!-- robots.txt file is more effective -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="<?php echo $content_charset; ?>">
 
 	<!-- Favicons -->
 	<link rel="mask-icon" href="/assets/images/favicons/favicon.svg" color="#fff"><!-- for apple -->
-	<link rel="icon" type="image/svg+xml" href="/assets/images/favicons/favicon.svg" >
+	<link rel="icon" type="image/svg+xml" href="/assets/images/favicons/favicon.svg">
 
 	<link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicons/favicon-32x32.png">
 	<link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicons/favicon-16x16.png">
@@ -45,32 +47,32 @@
 	<link rel="stylesheet" rev="stylesheet" href="/assets/css/template.css" type="text/css" media="screen">
 
 	<!--FontAwesome-->
-	<link href="/assets/css/all.min.css" rel="stylesheet"> 
+	<link href="/assets/css/all.min.css" rel="stylesheet">
 
 	<style>
 		#loading {
-		   width: 100%;
-		   height: 100%;
-		   top: 0px;
-		   left: 0px;
-		   position: fixed;
-		   display: none;
-		   opacity: 0.7;
-		   background-color: #fff;
-		   z-index: 99;
-		   text-align: center;
+			width: 100%;
+			height: 100%;
+			top: 0px;
+			left: 0px;
+			position: fixed;
+			display: none;
+			opacity: 0.7;
+			background-color: #fff;
+			z-index: 99;
+			text-align: center;
 		}
 
 		#loading-image {
-		  position: absolute;
-		  top:50%;
-		  left:50%;
-		  margin:-100px 0 0 -150px;
-		  z-index: 100;
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			margin: -100px 0 0 -150px;
+			z-index: 100;
 		}
 	</style>
-		
-<?php
-include ("css_settings.php");
-?>
+
+	<?php
+	include("css_settings.php");
+	?>
 </head>


### PR DESCRIPTION
Urgent correction

The absence of the <meta charset="<?php echo $content_charset; ?>"> tag causes several encoding errors, breaking accents, as shown in the image below.
<img width="1333" height="553" alt="image" src="https://github.com/user-attachments/assets/b38fe5d9-311e-40a8-a4db-a4dc0d28b2b3" />
