### PR TITLE
Update instructions

### DIFF
--- a/zz_installation/installation_instructions.md
+++ b/zz_installation/installation_instructions.md
@@ -24,7 +24,7 @@ Other components are indicated as prerequisites and not distributed with ABCD.
 In order to minimize security problems the latest version is recommended. ABCD requires for a minimal installation at least
   - Module `mod_cgi`: To allow execution of CGI scripts
   - Module `mod_rewrite` : To allow rewrite rules in the `.htaccess` file
-- A PHP processor. The unicode implementation of ABCD requires PHP 7.4.x. ABCD is not tested on PHP 8 (yet)
+- A PHP processor. The unicode implementation of ABCD requires PHP 8.1.x. ABCD is not tested on PHP 8 (yet)
 The default loaded extensions depend on the actual PHP processor. ABCD requires for a minimal installation at least
   - Extension `mbstring` : Multibyte support. To enable unicode.
   - Extension `gd` or `gd2` : Image functions. The name depends on the PHP implementation

--- a/zz_installation/installation_instructions_pt-br.md
+++ b/zz_installation/installation_instructions_pt-br.md
@@ -25,7 +25,7 @@ O módulo EmpWeb (módulo avançado de empréstimos) tem uma tecnologia completa
 A fim de minimizar os problemas de segurança, recomenda-se a versão mais recente. O ABCD requer, no mínimo, uma instalação
   - Módulo `mod_cgi`: Para permitir a execução de scripts CGI
   - Módulo `mod_rewrite` : Para permitir a reescrita de regras no arquivo 
-- Um processador PHP. A implementação unicode do ABCD requer PHP 7.4.x.
+- Um processador PHP. A implementação unicode do ABCD requer PHP 8.1.x.
 As extensões carregadas por padrão dependem do processador PHP real. O ABCD requer uma instalação mínima, pelo menos
   - Extensão `mbstring` : Suporte multibyte. Para ativar o unicode.
   - Extensão `gd` or `gd2` : Funções de imagem. O nome depende da implementação do PHP.

--- a/zz_installation/whats_new.md
+++ b/zz_installation/whats_new.md
@@ -181,7 +181,7 @@ Incorrect configuration inhibits the `Show/print` functionality and shows links 
 The code has dozens of changes to make it more robust, error resistant, improve feedback and corrections to generate valid HTML.
 
 Major milestones:
-- The code is compliant with PHP 7.4.
+- The code is compliant with PHP 8.1.
 - **`https`** is accepted by the code. This protocol is recommended for security.
 - Isis database architectures `16-60` and `bigisis` are supported for Linux and Windows for charactersets `ISO-8859-1` and `UTF-8`.
 This was already the case for Linux.  

--- a/zz_installation/whats_new_pt-br.md
+++ b/zz_installation/whats_new_pt-br.md
@@ -141,7 +141,7 @@ Observe que os arquivos de idioma ISO-8859-1 serão traduzidos dinamicamente par
 O código possui dezenas de alterações para torná-lo mais robusto, resistente a erros, melhorar o feedback e correções para gerar HTML válido.
 
 Principais marcos:
-- O código é compatível com PHP 7.4.
+- O código é compatível com PHP 8.1.
 - **`https`** é aceito pelo código. Este protocolo é recomendado para segurança.
 - Suporte para `Secs` (Serials Control System) teve que ser encerrado devido ao término da manutenção para plug-ins essenciais.
 - As arquiteturas de banco de dados Isis `16-60` e `bigisis` são suportadas para Linux e Windows para conjuntos de caracteres `ISO-8859-1` e `UTF-8`.


### PR DESCRIPTION
OPAC is not compatible with PHP 7.x.x, but it is compatible with PHP 8.1.x through 8.3.x. For security reasons, 8.1.x is recommended.