### PR TITLE
Updates OPAC help

### DIFF
--- a/www/htdocs/central/common/inc_div-helper.php
+++ b/www/htdocs/central/common/inc_div-helper.php
@@ -21,21 +21,22 @@ $server_script = $_SERVER['PHP_SELF'];
 if (isset($ayuda)) {
     $help_file = $ayuda;
 } else {
-    $help_file = strstr($including_file,".php",true).".html";
+    $help_file = strstr($including_file, ".php", true) . ".html";
 }
 // If the including name is already in the server script: no need to display
-if (strstr($server_script,$including_file,true)!=false) unset($including_file);
+if (strstr($server_script, $including_file, true) != false) unset($including_file);
 ?>
 <div class="helper">
-	<a href="../documentacion/ayuda.php?help=<?php echo $_SESSION["lang"]."/$help_file"?>" target=_blank><?php echo $msgstr["help"]?></a>
-<?php if (isset($_SESSION["permiso"]["CENTRAL_EDHLPSYS"])) {?>
-    &nbsp;&nbsp;<a href="../documentacion/edit.php?archivo=<?php echo $_SESSION["lang"]."/$help_file"?>" target=_blank><?php echo $msgstr["edhlp"]?></a>
-<?php } ?>
-<?php if (isset($wiki_help)) {?>
-    &nbsp;&nbsp;<a href="http://abcdwiki.net/<?php echo $wiki_help?>" target=_blank>abcdwiki</a>
-<?php }?>
-<?php if (isset($n_wiki_help)) {?>
-    &nbsp;&nbsp;<a href="https://abcd-community.github.io/wiki/<?php echo $n_wiki_help?>" target=_blank>wiki</a>
-<?php }?>
-	&nbsp;&nbsp;Script: <?php echo $server_script; if (isset($including_file)) echo "&#8594;".$including_file; ?> 
+    <a href="../documentacion/ayuda.php?help=<?php echo $_SESSION["lang"] . "/$help_file" ?>" target=_blank><?php echo $msgstr["help"] ?></a>
+    <?php if (isset($_SESSION["permiso"]["CENTRAL_EDHLPSYS"])) { ?>
+        &nbsp;&nbsp;<a href="../documentacion/edit.php?archivo=<?php echo $_SESSION["lang"] . "/$help_file" ?>" target=_blank><?php echo $msgstr["edhlp"] ?></a>
+    <?php } ?>
+    <?php if (isset($wiki_help)) { ?>
+        &nbsp;&nbsp;<a href="http://abcdwiki.net/<?php echo $wiki_help ?>" target=_blank>abcdwiki</a>
+    <?php } ?>
+    <?php if (isset($n_wiki_help)) { ?>
+        &nbsp;&nbsp;<a href="https://abcd-devcom.github.io/docs/<?php echo $n_wiki_help ?>" target=_blank>wiki</a>
+    <?php } ?>
+    &nbsp;&nbsp;Script: <?php echo $server_script;
+                        if (isset($including_file)) echo "&#8594;" . $including_file; ?>
 </div>

--- a/www/htdocs/central/settings/opac/adm_email.php
+++ b/www/htdocs/central/settings/opac/adm_email.php
@@ -3,7 +3,7 @@ include ("conf_opac_top.php");
 
 if ($_SESSION["profile"]=="adm"){ 
 
-$wiki_help="OPAC-ABCD_configuraci%C3%B3n#Par.C3.A1metros_globales";
+$n_wiki_help= "abcd-modules/opac-abcd/opac-admin/global/email-config";
 include "../../common/inc_div-helper.php";
 ?>
 

--- a/www/htdocs/central/settings/opac/alpha_ix.php
+++ b/www/htdocs/central/settings/opac/alpha_ix.php
@@ -1,6 +1,7 @@
 <?php
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_configuraci%C3%A3n_avanzada#.C3.8Dndices_alfab.C3.A9ticos";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/alpha_ix";
+
 include "../../common/inc_div-helper.php";
 
 $update_message = ""; // Variável para feedback

--- a/www/htdocs/central/settings/opac/autoridades.php
+++ b/www/htdocs/central/settings/opac/autoridades.php
@@ -1,6 +1,6 @@
 <?php
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_configuraci%C3%B3n_avanzada#Extracci.C3.B3n_de_claves_para_presentar_el_.C3.ADndice";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/index-extraction";
 include "../../common/inc_div-helper.php";
 ?>
 

--- a/www/htdocs/central/settings/opac/databases.php
+++ b/www/htdocs/central/settings/opac/databases.php
@@ -13,7 +13,7 @@
 
 
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_configuraci%C3%B3n#Bases_de_datos_disponibles";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/databases";
 include "../../common/inc_div-helper.php";
 
 //foreach ($_REQUEST as $var=>$value) echo "$var=>$value<br>";  die;

--- a/www/htdocs/central/settings/opac/dbn_par.php
+++ b/www/htdocs/central/settings/opac/dbn_par.php
@@ -5,7 +5,7 @@
  */
 
 include ("conf_opac_top.php");
-$wiki_help="OPAC-ABCD_Configuraci%C3%B3n_de_bases_de_datos#Edici.C3.B3n_del_dbn.par";
+$n_wiki_help= "abcd-modules/opac-abcd/opac-admin/databases/dbn-par";
 include "../../common/inc_div-helper.php";
 ?>
 

--- a/www/htdocs/central/settings/opac/diagnostico.php
+++ b/www/htdocs/central/settings/opac/diagnostico.php
@@ -17,10 +17,9 @@
 */
 
 
-$n_wiki_help = "docs/es/6-opac/more-config";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/tools/diagnostics";
 $config_file = "../../config_opac.php";
 
-//include "../../config_opac.php";
 $no_err = 0;
 include("conf_opac_top.php");
 include "../../common/inc_div-helper.php";

--- a/www/htdocs/central/settings/opac/edit_form-search.php
+++ b/www/htdocs/central/settings/opac/edit_form-search.php
@@ -16,7 +16,7 @@
  */
 
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_Configuraci%C3%B3n_de_bases_de_datos#B.C3.BAsqueda_Libre";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/search-forms";
 include "../../common/inc_div-helper.php";
 
 // A função file_get_contents_utf8() foi movida para opac_functions.php (incluído via conf_opac_top.php)

--- a/www/htdocs/central/settings/opac/edit_relevance.php
+++ b/www/htdocs/central/settings/opac/edit_relevance.php
@@ -14,7 +14,7 @@ ________________________________________________________________________________
 */
 
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_configuraci%C3%A3n_avanzada#Relevance_Configuration";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/relevance";
 include "../../common/inc_div-helper.php";
 
 $update_message = ""; // Variável para feedback

--- a/www/htdocs/central/settings/opac/edit_restriction.php
+++ b/www/htdocs/central/settings/opac/edit_restriction.php
@@ -14,7 +14,7 @@ ________________________________________________________________________________
 */
 
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_configuraci%C3%A3n_avanzada#Restricted_Records";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/restricted-access";
 include "../../common/inc_div-helper.php";
 
 // --- Funções Auxiliares ---

--- a/www/htdocs/central/settings/opac/facetas_cnf.php
+++ b/www/htdocs/central/settings/opac/facetas_cnf.php
@@ -11,7 +11,7 @@
 */
 
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_configuraci%C3%B3n_avanzada#Facetas";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/facets";
 include "../../common/inc_div-helper.php";
 
 if ($_REQUEST["base"] == "META") {

--- a/www/htdocs/central/settings/opac/footer_cfg.php
+++ b/www/htdocs/central/settings/opac/footer_cfg.php
@@ -1,6 +1,6 @@
 <?php
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_Apariencia#Pie_de_p.C3.A1gina";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/appearance/cms-layout#3-footer-and-header";
 include "../../common/inc_div-helper.php";
 ?>
 

--- a/www/htdocs/central/settings/opac/formatos_salida.php
+++ b/www/htdocs/central/settings/opac/formatos_salida.php
@@ -81,7 +81,7 @@ if (isset($_REQUEST["Opcion"]) and $_REQUEST["Opcion"] == "Guardar") {
 // =================================================================
 
 
-$wiki_help = "OPAC-ABCD_Configuraci%C3%B3n_de_bases_de_datos#B.C3.BAsqueda_Libre";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/display-formats";
 include "../../common/inc_div-helper.php";
 ?>
 

--- a/www/htdocs/central/settings/opac/horizontal_menu.php
+++ b/www/htdocs/central/settings/opac/horizontal_menu.php
@@ -1,6 +1,6 @@
 <?php
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_Apariencia#Agregar_enlaces_al_men.C3.BA_superior_horizontal";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/appearance/cms-layout#3-footer-and-header";
 include "../../common/inc_div-helper.php";
 
 // =================================================================

--- a/www/htdocs/central/settings/opac/index.php
+++ b/www/htdocs/central/settings/opac/index.php
@@ -3,7 +3,7 @@
 if (isset($_REQUEST["conf_level"])) unset($_REQUEST["conf_level"]);
 include ("conf_opac_top.php");
 
-$wiki_help="OPAC-ABCD_Detalles_de_la_configuraci%C3%B3n#Men.C3.BA_de_configuraci.C3.B3n";
+$n_wiki_help= "abcd-modules/opac-abcd/opac-admin";
 include "../../common/inc_div-helper.php";
 ?>
 

--- a/www/htdocs/central/settings/opac/pagina_inicio.php
+++ b/www/htdocs/central/settings/opac/pagina_inicio.php
@@ -1,6 +1,6 @@
 <?php
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_Apariencia#Primera_p.C3.A1gina";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/appearance/cms-layout#1-the-home-page-home_1html";
 include "../../common/inc_div-helper.php";
 
 $config_dir = $db_path . "opac_conf/" . $lang . "/";

--- a/www/htdocs/central/settings/opac/parametros.php
+++ b/www/htdocs/central/settings/opac/parametros.php
@@ -13,7 +13,7 @@
 * 2025-11-16 rogercgui Corrected upload logic to save relative paths (uploads/file.png) instead of absolute URLs
 */
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_configuraci%C3%B3n#Par.C3.A1metros_globales";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/global/general";
 include "../../common/inc_div-helper.php";
 
 $update_message = ""; // Variável para feedback

--- a/www/htdocs/central/settings/opac/presentacion.php
+++ b/www/htdocs/central/settings/opac/presentacion.php
@@ -1,6 +1,6 @@
 <?php
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_Apariencia#Estilos";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/appearance/appearance";
 include "../../common/inc_div-helper.php";
 ?>
 

--- a/www/htdocs/central/settings/opac/record_toolbar.php
+++ b/www/htdocs/central/settings/opac/record_toolbar.php
@@ -1,6 +1,6 @@
 <?php
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD_Barra_de_Herramientas";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/toolbar";
 include "../../common/inc_div-helper.php";
 
 // =================================================================

--- a/www/htdocs/central/settings/opac/sidebar_menu.php
+++ b/www/htdocs/central/settings/opac/sidebar_menu.php
@@ -1,6 +1,6 @@
 <?php
 include ("conf_opac_top.php");
-$wiki_help="OPAC-ABCD_Apariencia#Agregar_enlaces_al_men.C3.BA_desplegable_izquierdo";
+$n_wiki_help= "abcd-modules/opac-abcd/opac-admin/appearance/cms-layout#2-sidebar-widgets-side_barinfo";
 include "../../common/inc_div-helper.php";
 ?>
 

--- a/www/htdocs/central/settings/opac/tipos_registro.php
+++ b/www/htdocs/central/settings/opac/tipos_registro.php
@@ -1,6 +1,6 @@
 <?php
 include ("conf_opac_top.php");
-$wiki_help="OPAC-ABCD_configuraci%C3%B3n_avanzada#Tipos_de_registro";
+$n_wiki_help="abcd-modules/opac-abcd/opac-admin/databases/record-types";
 include "../../common/inc_div-helper.php";
 
 ?>

--- a/www/htdocs/central/settings/opac/view_dic.php
+++ b/www/htdocs/central/settings/opac/view_dic.php
@@ -17,6 +17,10 @@ ob_start();
 
 include("conf_opac_top.php");
 
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/did-you-mean";
+
+include "../../common/inc_div-helper.php";
+
 // Defines the main variables that will be used in all routes.
 $base = isset($_REQUEST["base"]) ? $_REQUEST["base"] : null;
 $lang = isset($_REQUEST["lang"]) ? $_REQUEST["lang"] : "pt";

--- a/www/htdocs/central/settings/opac/view_search.php
+++ b/www/htdocs/central/settings/opac/view_search.php
@@ -10,7 +10,7 @@
 */
 
                                             include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD DCXML";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/tools/search-analytics";
 include "../../common/inc_div-helper.php";
 
 // --- INÍCIO DAS MODIFICAÇÕES ---

--- a/www/htdocs/central/settings/opac/xml_dc.php
+++ b/www/htdocs/central/settings/opac/xml_dc.php
@@ -7,7 +7,7 @@
  */
 
 include("conf_opac_top.php");
-$wiki_help = "OPAC-ABCD DCXML";
+$n_wiki_help = "abcd-modules/opac-abcd/opac-admin/databases/metadata-xml#2-dublin-core-configuration";
 include "../../common/inc_div-helper.php";
 
 ?>

--- a/www/htdocs/central/settings/opac/xml_marc.php
+++ b/www/htdocs/central/settings/opac/xml_marc.php
@@ -1,6 +1,6 @@
 <?php
 include ("conf_opac_top.php");
-$wiki_help="OPAC-ABCD_MARCXML";
+$n_wiki_help= "abcd-modules/opac-abcd/opac-admin/databases/metadata-xml#1-marcxml-configuration";
 include "../../common/inc_div-helper.php";
 ?>
 


### PR DESCRIPTION
Point the top help links to the new documentation at: https://abcd-devcom.github.io/docs/category/opac-public-catalog