### PR TITLE
Add clear-field button styles and fix textCounter refs

### DIFF
--- a/www/htdocs/assets/css/main.css
+++ b/www/htdocs/assets/css/main.css
@@ -1985,6 +1985,40 @@ td.no-wrap {
     margin-bottom: 30px;
 }
 
+.btn-limpar-abcd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 6px;
+    margin-left: 4px;
+    color: #444;
+    background-color: #f0f0f0;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    text-decoration: none !important;
+    font-size: 0.9em;
+    cursor: pointer;
+    vertical-align: middle;
+    height: 28px;
+    box-sizing: border-box;
+}
+.btn-limpar-abcd:hover {
+    background-color: #e8e8e8;
+    color: #d9534f;
+    border-color: #adadad;
+}
+
+textarea+.btn-limpar-abcd {
+    vertical-align: top;
+    margin-top: 2px;
+}
+
+/* Ensures that no field is wide enough to break the row of buttons */
+.table-fdt-four input[type="text"],
+.table-fdt-four textarea {
+    max-width: calc(100% - 150px) !important;
+}
+
 /* ==========================================================================
    8. SPECIFIC STYLES OF PAGES AND COMPONENTS
    ========================================================================== */

--- a/www/htdocs/central/dataentry/dibujarhojaentrada.php
+++ b/www/htdocs/central/dataentry/dibujarhojaentrada.php
@@ -964,8 +964,8 @@ function TextBox($linea, $fondocelda, $titulo, $ver, $len, $tag, $ksc, $rep, $de
 					$campo = $campo;
 				}
 				if ($maxlength > 0) {
-					echo " onKeyDown=\"textCounter(document.forma$ixforms.tag_" . $tag . ",document.forma$ixforms.rem$tag,$maxlength)\"
-			   onKeyUp=\"textCounter(document.forma1.tag" . $tag . ",document.forma1.rem$tag,$maxlength)\"";
+					echo " onKeyDown=\"textCounter(document.forma1.tag" . $tag . ", document.forma1.rem$tag, $maxlength)\"
+               onKeyUp=\"textCounter(document.forma1.tag" . $tag . ", document.forma1.rem$tag, $maxlength)\"";
 				}
 				echo ' onKeyUp="CheckInventory()" >' . $campo . "</textarea>";
 				if ($maxlength > 0)
@@ -1916,7 +1916,6 @@ function TextBox($linea, $fondocelda, $titulo, $ver, $len, $tag, $ksc, $rep, $de
 		require_once("../dataentry/javascript_validation.php");
 	}
 					?>
-
 <script>
 document.addEventListener("DOMContentLoaded", function() {
     var seletores = 'input[type="text"][name^="field"], input[type="text"][name^="tag"], textarea[name^="field"], textarea[name^="tag"]';
@@ -1929,8 +1928,8 @@ document.addEventListener("DOMContentLoaded", function() {
 
         var btnLimpar = document.createElement('a');
         btnLimpar.href = 'javascript:void(0);';
-        btnLimpar.title = 'Limpar campo';
-        btnLimpar.className = 'bt-fdt mb-2 mt-0'; 
+        btnLimpar.title = 'Clear field';
+        btnLimpar.className = 'btn-limpar-abcd'; 
         btnLimpar.innerHTML = '<i class="fas fa-eraser"></i>'; 
         
         campo.parentNode.insertBefore(btnLimpar, campo.nextSibling);


### PR DESCRIPTION
Introduce .btn-limpar-abcd CSS for a compact clear-field button and prevent inputs/textareas in .table-fdt-four from growing wide enough to break button rows. In PHP, unify textCounter calls to use document.forma1 to fix incorrect form references. Update the DOM-inserted clear button: change its class to btn-limpar-abcd and its title to English ('Clear field'). Also remove a stray blank line in the generated output.

**Before**
<img width="1362" height="582" alt="image" src="https://github.com/user-attachments/assets/4c5e2c6d-4aca-4841-ac8a-4cd207df5c7a" />


**After**
<img width="1359" height="630" alt="image" src="https://github.com/user-attachments/assets/2c7e3fd8-1fc1-4edd-b65b-282ed1fb0aad" />



Note:
This adjustment was made following complaints from some users about there being too much white space in the data entry field.