### PR TITLE
Rebuild SubC JS and handle picklists/indicators

### DIFF
--- a/www/htdocs/central/dataentry/campos.php
+++ b/www/htdocs/central/dataentry/campos.php
@@ -5,6 +5,8 @@
 20250402 fho4abcd Improved html, removed obsolete code and redundant spacing
 20250402 fho4abcd Added standard breadcrumb & action div. Action buttons: moved to top, modified text, hover and color
 20250402 fho4abcd Added translations for js. Added standard helper and footer
+20260529 rogercgui Implement type IND for indicators, added historical fallback for older databases that still use ‘S’ for indicators, added comments and improved code readability
+
 */
   session_start();
 if (!isset($_SESSION["permiso"])){
@@ -19,6 +21,7 @@ include("../common/header.php");
 
 // Extract the subfields
 $fp=explode("\n",$arrHttp["SubC"]);
+
 $subc="";
 foreach ($fp as $linea){
 	$linea=trim($linea);
@@ -44,31 +47,55 @@ echo "is_marc='".$arrHttp["is_marc"]."'\n";
 echo "PickList=new Array()\n";
 echo "NamePickList=new Array()\n";
 echo "SubCampos=new Array()\n";
-foreach ($fp as $linea){
-	$linea=trim($linea);
-	if (trim($linea)!=""){
-		$l=explode('|',$linea);
-		$ix=$ix+1;
-		if ($l[0]=="S") {
-			$ind_sc=$ix;
-	        $Ind="";
-	        if ($ind_sc<2 and $arrHttp["is_marc"]=="S"){
-	           	if (substr($subc,$ind_sc,1)==1 or substr($subc,$ind_sc,1)==2)
-	           		$Ind="I";
-	        }
-	        $key=$Ind.substr($subc,$ind_sc,1);
-			if (trim($l[11])!=""){
-				echo "NamePickList['".$key."']='".$l[11]."'\n";
-				PickList($key,$l[11]);
-			}else{
-				$l=$ix-1;
-				echo "PickList['".$key."']=''\n";
+
+// Array para reconstruir a variável SubC global do JS legado
+$subc_js_array = array();
+
+foreach ($fp as $linea) {
+	$linea = trim($linea);
+	if ($linea != "") {
+		$l = explode('|', $linea);
+
+		// Processes only Indicators (IND) and Subfields (S), as per the original logic
+		if (isset($l[0]) && ($l[0] == "S" || $l[0] == "IND")) {
+
+			// Adds the entire row to the array that JavaScript uses to build the table in a rigid manner
+			$subc_js_array[] = $linea;
+
+			$code = isset($l[5]) ? trim($l[5]) : "";
+			$key = $code;
+
+			// Power the I1 and I2 switches for the indicators
+			if ($l[0] == "IND") {
+				$key = "I" . $code;
 			}
-			echo "SubCampos['$key']='$key'\n";
-		}else{
+			// Historical fallback for older databases that still use ‘S’ for indicators
+			elseif (count($subc_js_array) <= 2 && isset($arrHttp["is_marc"]) && $arrHttp["is_marc"] == "S") {
+				if ($code == "1" || $code == "2") {
+					$key = "I" . $code;
+				}
+			}
+
+			// Populate the picklists and their names based on the configuration
+			if (isset($l[11]) && trim($l[11]) != "") {
+				echo "NamePickList['" . $key . "']='" . addslashes(trim($l[11])) . "'\n";
+				PickList($key, trim($l[11]));
+			} else {
+				echo "PickList['" . $key . "']=''\n";
+			}
+
+			// Alimenta os rótulos de forma indexada
+			$label = isset($l[2]) ? trim($l[2]) : $key;
+			echo "SubCampos['" . $key . "']='" . addslashes($label) . "'\n";
 		}
 	}
 }
+
+// RECONSTRUCT THE SUBC VARIABLE
+// The JavaScript 'editarocurrencias.js' performs a .split("\\n") on it and bases the entire for loop on it
+$subc_string_final = implode("\\n", $subc_js_array);
+echo "SubC = \"" . addslashes($subc_string_final) . "\";\n";
+
 // Next statements define variables for the textstrings used in the js files
 echo "trn_mod_picklist=\"".$msgstr["mod_picklist"]."\"\n";
 echo "trn_reload_picklist=\"".$msgstr["reload_picklist"]."\"\n";

--- a/www/htdocs/central/dataentry/js/editarocurrencias.js
+++ b/www/htdocs/central/dataentry/js/editarocurrencias.js
@@ -2,6 +2,7 @@
 20250402 fho4abcd More readable code, improve generated html, add translation and hovered texts
 20250402 fho4abcd Copy default from worksheet to <input value=...>, replace dropdown by button
 20250901 fho4abcd Copy default from worksheet for dropdown list in case of redraw command
+20260529 rogercgui Implement type IND for indicators, added historical fallback for older databases that still use ‘S’ for indicators, added comments and improved code readability
 */
 // The occurrences of the field / para colocar las ocurrencias del campo
 var valoresCampo=new Array(200)
@@ -60,12 +61,30 @@ nSC=SubCampos.length
 valoresCampo = Contenido.split("\n")
 
 // The Select is created for the occurrences of the field/  Se crea el Select para las ocurrencias del campo
-Titulo=window.opener.NombreC
+Titulo = window.opener.NombreC
 //  alert( "titel="+Titulo)
-Tx=Titulo.split('|')
+
+Tx = Titulo.split('|')
 // Fields: 0:Type, 1:Tag, 2:Title, 3:I, 4:Repeatable, 5:Subfield(s), 6:Input type, 7:rows, 8:cols,
 //         9:PL-Type, 10:PL-Name, 11:PL:Prefix, 12:PL-Detail, 13:List-as, 14:Extract-as,
 //         15:Default, 16:Help, 17:Help-URL, 18:Link-FDT, 19:Req?, 20:Field-Validation
+
+
+// ==== ABCD CORRECTION: DYNAMIC RECONSTRUCTION OF SUBFIELDS ====
+// Ensures that the renderer reads all subfields (including IND)
+// even if the cataloguer has forgotten to declare them in the main FDT.
+var subc_reais = "";
+for (var k = 0; k < nSC; k++) {
+	if (Trim(SubCampos[k]) != "") {
+		var xparts = SubCampos[k].split('|');
+		if (xparts.length > 5 && xparts[5]) {
+			subc_reais += xparts[5];
+		}
+	}
+}
+if (subc_reais != "") {
+	Tx[5] = subc_reais;
+}
 
 // write the leading question mark
 document.write("<table width=950 cellpadding=0 cellspacing=0>")


### PR DESCRIPTION
Refactor campos.php parsing to collect IND/S rows into a JS-friendly SubC string and simplify picklist/label population. The PHP now accumulates relevant rows into subc_js_array, handles both "S" and "IND" marker types (with a historical fallback), builds picklist/name entries with proper escaping, and emits SubC as a single \n-separated JS string. Update editarocurrencias.js to dynamically reconstruct the actual subfields (subc_reais) from SubCampos and inject them into Tx[5], ensuring the renderer sees indicators/subfields even when they were omitted from the main FDT. Improves compatibility with older DB formats and makes picklist/indicator handling more robust.

Fixes #655 .