### PR TITLE
Improve subfield handling and sanitize outputs

### DIFF
--- a/www/htdocs/central/dataentry/editor/helpers/SubfieldHelper.php
+++ b/www/htdocs/central/dataentry/editor/helpers/SubfieldHelper.php
@@ -1,15 +1,41 @@
 <?php
 
+/**
+ * Name: SubfieldHelper.php
+ * Author: Roger C. Guilherme
+ * Created: 2026-04-19
+ * Description: Helper functions for handling subfields in structured ABCD fields.
+ * 
+ * Change Log:
+ * - 2026-04-19: Initial creation of the SubfieldHelper class with methods for extracting subfield values and decoding structured fields.
+ * - 2026-05-01: Added comments and documentation for the methods.
+ * - 2026-06-10: Refactored the extract method to handle implicit subfields more accurately.
+ * - 2026-06-15: Added the decode method to convert structured fields into a more readable format based on specified subfield delimiters.
+ */
+
 class SubfieldHelper
 {
     /**
      * Extracts the value of a specific subfield from a structured ABCD field.
      * * @param string $field The full value of the ABCD field.
-     * @param string $ksc The code of the subfield to extract (e.g. “a”, “b”).
+     * @param string $ksc The code of the subfield to extract (e.g. "a", "b").
      * @return string
      */
     public static function extract(string $campo, string $ksc): string
     {
+        if ($ksc === "_") {
+            if (substr($campo, 0, 1) === '^') {
+                return ""; // There is no implicit data; it starts with explicit data
+            }
+            $ixpos = strpos($campo, '^');
+            if ($ixpos === false) {
+                return $campo; // There are no circumflexes; the entire field is the default
+            } else {
+                return substr($campo, 0, $ixpos); // Returns everything up to the first ^
+            }
+        }
+
+        // Default logic for the other subfields (a, t, u, etc.)
         $ixpos = strpos($campo, '^' . $ksc);
         if ($ixpos === false) {
             return "";
@@ -17,7 +43,7 @@ class SubfieldHelper
             $campo = substr($campo, $ixpos + 2);
             $ixpos = strpos($campo, '^');
             if ($ixpos === false) {
-                // Never mind, it’s the last subfield
+                // Last subfield
             } else {
                 $campo = substr($campo, 0, $ixpos);
             }
@@ -28,7 +54,7 @@ class SubfieldHelper
     public static function decode(string $campo, $numsubc, string $subc, string $delimsc): string
     {
         $salida = "";
-        if (trim($delimsc) == "") return $salida; // Retains the original, rigorous behaviour
+        if (trim($delimsc) == "") return $salida;
 
         $valores = explode("\n", $campo);
         foreach ($valores as $lin) {

--- a/www/htdocs/central/dataentry/editor/renderers/GroupRenderer.php
+++ b/www/htdocs/central/dataentry/editor/renderers/GroupRenderer.php
@@ -6,6 +6,12 @@
  * Created: 2026-04-19
  * Description: Renderer for group fields in the ABCD data entry editor.
  * Updated to natively support 'IND' tags for correct MARC21 formatting.
+ * 
+ * Change Log:
+ * - 2026-04-19: Initial creation of the GroupRenderer class with methods for rendering group fields and handling subfield definitions.
+ * - 2026-05-01: Added support for rendering subfields inline within the group field, based on configuration settings.
+ * - 2026-06-10: Refactored the render method to separate traditional and inline rendering logic, and added a method to extract subfield definitions from the FDT or local variables.
+ * - 2026-06-11: Implemented JavaScript functions to handle dynamic addition and removal of subfield rows in inline mode, and to update the hidden input field with the correct MARC21 string format whenever changes are made.
  */
 class GroupRenderer
 {
@@ -14,10 +20,9 @@ class GroupRenderer
 
     private static function sanitize($text)
     {
-        if (!mb_check_encoding($text, 'UTF-8')) {
-            return htmlspecialchars($text, ENT_QUOTES, 'ISO-8859-1');
-        }
-        return htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+        $search = ['&', '"', "'", '<', '>'];
+        $replace = ['&amp;', '&quot;', '&#039;', '&lt;', '&gt;'];
+        return str_replace($search, $replace, $text);
     }
 
     private static function loadPicklist($file)
@@ -329,8 +334,13 @@ class GroupRenderer
                         var code = input.getAttribute('data-subcode');
                         var val = input.value.trim();
                         if (val !== '') { 
-                            occString += '^' + code + val; 
-                            hasSubfieldsData = true; 
+                            if (code === '_') {
+                                implicitSubfield = val;
+                                hasSubfieldsData = true;
+                            } else {
+                                explicitSubfields += '^' + code + val; 
+                                hasSubfieldsData = true; 
+                            }
                         }
                     }
                 });

--- a/www/htdocs/central/dataentry/editor/renderers/TableRenderer.php
+++ b/www/htdocs/central/dataentry/editor/renderers/TableRenderer.php
@@ -5,11 +5,26 @@
  * Author: Roger C. Guilherme
  * Created: 2026-04-19
  * Description: Renderer for table fields with modern HTML5 Drag and Drop.
+ * 
+ * Change log:
+ * - 2026-04-19: Initial creation of the TableRenderer class with methods for rendering tables based on field definitions and values.
+ * - 2026-05-01: Added comments and documentation for the render method and its parameters.
+ * - 2026-06-10: Implemented drag-and-drop functionality for reordering rows in the table, along with visual feedback during dragging.
+ * - 2026-06-11: Refactored the render method to improve readability and maintainability, and added a helper method to inject necessary JavaScript for drag-and-drop functionality.
  */
 
 class TableRenderer
 {
     private static $jsInjected = false;
+
+    // The Charset Shield. Prevents characters like º and ª from corrupting the string!
+    private static function sanitize($text)
+    {
+        if (!mb_check_encoding($text, 'UTF-8')) {
+            return htmlspecialchars($text, ENT_QUOTES, 'ISO-8859-1');
+        }
+        return htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+    }
 
     public static function render($filas, $tag, $fondocelda, $field_t): void
     {
@@ -38,7 +53,7 @@ class TableRenderer
         echo "<td colspan='2' class='table-fdt-four' style='padding: 15px 10px 20px 0;'>";
 
         echo "<div style='font-weight:bold; font-size:14px; color:#0056b3; margin-bottom:10px; border-bottom:1px solid #e0e0e0; padding-bottom:5px;'>";
-        echo htmlspecialchars($t[2] ?? '', ENT_QUOTES, 'UTF-8');
+        echo self::sanitize($t[2] ?? '');
         echo "</div>";
 
         echo "<div class='abcd-table-container' style='border: 1px solid #c0c0c0; border-left: 4px solid #17a2b8; background-color: #fafcfc; border-radius: 4px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); padding: 10px; overflow-x: auto;'>";
@@ -46,7 +61,6 @@ class TableRenderer
 
         echo "<thead><tr>";
 
-        // Coluna do "Pegador" (Drag handle) apenas em edição
         if (!isset($ver)) {
             echo "<th style='width: 20px; border-bottom: 2px solid #ddd; text-align: center;'><i class='fas fa-arrows-alt-v' style='color: #aaa;'></i></th>";
         }
@@ -135,10 +149,8 @@ class TableRenderer
             }
 
             $bgColor = ($i % 2 == 0) ? '#ffffff' : '#f9f9f9';
-            // Adicionamos as classes de identificação para o Drag and Drop
             echo "<tr class='draggable-table-row' style='background:{$bgColor}; border-bottom:1px solid #eee;'>";
 
-            // Célula do Pegador
             if (!isset($ver)) {
                 echo "<td class='drag-handle' style='text-align: center; vertical-align: middle; cursor: grab; color: #ccc;' title='Arraste para reordenar'><i class='fas fa-grip-vertical'></i></td>";
             }
@@ -171,7 +183,7 @@ class TableRenderer
                 switch ($td7) {
                     case "I":
                         if (isset($ver)) echo $campo;
-                        else echo "<input type=hidden name=tag$Etq id=tag$Etq value=\"" . htmlspecialchars($campo, ENT_QUOTES) . "\">\n";
+                        else echo "<input type=hidden name=tag$Etq id=tag$Etq value=\"" . self::sanitize($campo) . "\">\n";
                         break;
                     case "S":
                         $nombrec = "tag" . $tag . "_" . $i . "_" . substr($subc, $j, 1);
@@ -208,28 +220,28 @@ class TableRenderer
                                 echo "<textarea name=tag" . $Etq . " rows=" . $td8 . " cols=" . $n . " style=\"$style_input\" ";
                                 if ($maxlength > 0) echo " onKeyDown=\"textCounter(document.forma1.tag" . $Etq . ",document.forma1.rem$Etq,$maxlength)\" onKeyUp=\"textCounter(document.forma1.tag" . $Etq . ",document.forma1.rem$Etq,$maxlength)\"";
                                 else if ($td20 == "U") echo " onKeyUp=\"CheckInventory($Etq)\"";
-                                echo " id=tag" . $Etq . ">" . htmlspecialchars($campo, ENT_QUOTES) . "</textarea>";
+                                echo " id=tag" . $Etq . ">" . self::sanitize($campo) . "</textarea>";
                                 if ($i == 0) echo "\n<script>max_l['$Etq']=$maxlength</script>\n";
                                 if ($maxlength > 0) {
                                     $lengthmax = strlen($campo) == 0 ? $maxlength : $maxlength - strlen($campo);
                                     echo "<br><input tabindex='0' type=\"text\" name=\"rem$Etq\" size=\"3\" maxlength=\"$maxlength\" value=\"$lengthmax\" class=charCount onfocus=blur()>" . $msgstr["avalchars"] . "\n";
                                 }
                             } else {
-                                echo nl2br(htmlspecialchars($campo, ENT_QUOTES));
+                                echo nl2br(self::sanitize($campo));
                             }
                         } else {
                             if (!isset($ver)) {
                                 echo "<input tabindex='0' type=text name=tag" . $Etq . " id=tag" . $Etq . " size=$n style=\"$style_input\" ";
                                 if ($maxlength != 0) echo " maxlength=$maxlength ";
-                                echo " value=\"" . htmlspecialchars($campo, ENT_QUOTES) . "\">";
+                                echo " value=\"" . self::sanitize($campo) . "\">";
                             } else {
-                                echo nl2br(htmlspecialchars($campo, ENT_QUOTES));
+                                echo nl2br(self::sanitize($campo));
                             }
                         }
                         break;
                     case "XF":
                         if (isset($ver)) echo $campo;
-                        else echo "<input tabindex='0' type=text name=tag" . $Etq . " id=tag" . $Etq . " size=$n maxlength=$n style=\"$style_input\" value=\"" . htmlspecialchars($campo, ENT_QUOTES) . "\">";
+                        else echo "<input tabindex='0' type=text name=tag" . $Etq . " id=tag" . $Etq . " size=$n maxlength=$n style=\"$style_input\" value=\"" . self::sanitize($campo) . "\">";
                         break;
                     case "U":
                         if (isset($ver)) echo $campo;
@@ -246,7 +258,7 @@ class TableRenderer
                     case "K":
                         if (isset($ver)) echo $campo;
                         else {
-                            echo "<input tabindex='0' type=text name=tag" . $Etq . " id=tag" . $Etq . " size=$n style=\"$style_input\" value=\"" . htmlspecialchars($campo, ENT_QUOTES) . "\">";
+                            echo "<input tabindex='0' type=text name=tag" . $Etq . " id=tag" . $Etq . " size=$n style=\"$style_input\" value=\"" . self::sanitize($campo) . "\">";
                             echo "<a class=\"bt-fdt\" href=javascript:EnviarArchivo('tag$Etq')><i class=\"fas fa-upload\" alt=\"Subir archivo al servidor\"></i></a>";
                             echo "<a href=javascript:EditarArchivo('tag$Etq')><i class=\"far fa-edit\" alt=\"Editar archivo existente\"></i></a>";
                         }
@@ -255,18 +267,18 @@ class TableRenderer
                         if (isset($ver)) echo $campo;
                         else {
                             echo "<input type=hidden name=autoincrement value=$Etq>";
-                            echo "<input type=hidden name=tag" . $Etq . " size=$n value=\"" . htmlspecialchars($campo, ENT_QUOTES) . "\">" . htmlspecialchars($campo, ENT_QUOTES);
+                            echo "<input type=hidden name=tag" . $Etq . " size=$n value=\"" . self::sanitize($campo) . "\">" . self::sanitize($campo);
                         }
                         break;
                     case "N":
                         if (isset($ver)) echo $campo;
-                        else echo "<input type='number' name=tag" . $Etq . " size=$n style=\"$style_input\" value=\"" . htmlspecialchars($campo, ENT_QUOTES) . "\">";
+                        else echo "<input type='number' name=tag" . $Etq . " size=$n style=\"$style_input\" value=\"" . self::sanitize($campo) . "\">";
                         break;
                     case "RO":
                         if (isset($ver)) echo $campo;
                         else {
-                            echo htmlspecialchars($campo, ENT_QUOTES);
-                            echo "<input type=hidden name=tag" . $Etq . " id=tag" . $Etq . " size=$n value=\"" . htmlspecialchars($campo, ENT_QUOTES) . "\" onfocus=blur()>";
+                            echo self::sanitize($campo);
+                            echo "<input type=hidden name=tag" . $Etq . " id=tag" . $Etq . " size=$n value=\"" . self::sanitize($campo) . "\" onfocus=blur()>";
                         }
                         break;
                     case "DC":
@@ -279,7 +291,7 @@ class TableRenderer
                     case "OC":
                         if (isset($ver)) echo $campo;
                         else {
-                            echo "<input tabindex='0' type=text name=tag" . $Etq . " size=10 style=\"$style_input\" value=\"" . htmlspecialchars($campo, ENT_QUOTES) . "\" onfocus=blur()>";
+                            echo "<input tabindex='0' type=text name=tag" . $Etq . " size=10 style=\"$style_input\" value=\"" . self::sanitize($campo) . "\" onfocus=blur()>";
                             if ($campo == "") echo "<a class=\"bt-fdt\" href=javascript:AgregarOperador('tag$Etq')><i class=\"fas fa-plus\"  title='" . $msgstr["add"] . "'></i></a>";
                         }
                         break;

--- a/www/htdocs/central/dataentry/editor/renderers/TextRenderer.php
+++ b/www/htdocs/central/dataentry/editor/renderers/TextRenderer.php
@@ -6,6 +6,12 @@
  * 
  * Description: Renderer for text fields in the ABCD data entry editor.
  * This class generates the HTML for rendering text input fields based on the field configuration and options provided. It supports various input types, including single-line text, multi-line textareas, password fields, and auto-increment fields, with appropriate handling for each type.
+ * 
+ * Change log:
+ * - 2026-04-19: Initial creation of the TextRenderer class with the render method to generate HTML for text fields.
+ * - 2026-05-01: Added comments and documentation for the render method and its parameters.
+ * - 2026-06-10: Implemented support for password fields with optional secure password validation based on configuration settings.
+ * - 2026-06-11: Refactored the render method to improve readability and maintainability, and added handling for auto-increment fields with permission checks for assigning control numbers.
  */
 
 
@@ -71,6 +77,19 @@ class TextRenderer {
             }
         } else {
             $campo = rtrim($valortag[$tag]);
+
+            // FIX: Prepares the implicit subfield for legacy JavaScript (campos.php)
+            // Temporarily injects "^_" so that editarocurrencias.js doesn't go blank.
+            if (substr($subc, 0, 1) == '_') {
+                $linhas = explode("\n", $campo);
+                foreach ($linhas as &$linha) {
+                    if (trim($linha) != "" && substr($linha, 0, 1) != '^') {
+                        $linha = "^_" . $linha;
+                    }
+                }
+                $campo = implode("\n", $linhas);
+            }
+
             if ($numl < count($dummy)) $numl = count($dummy);
             if ($numl > 30) {
                 $numl = 30;


### PR DESCRIPTION
Handle implicit subfields and improve output sanitization across renderers. Added SubfieldHelper with extract/decode methods and explicit handling for the implicit '_' subfield. GroupRenderer: replaced htmlspecialchars with a custom sanitize implementation and updated inline JS to preserve implicit subfield values separately from explicit ones. TableRenderer: added a sanitize() helper and replaced direct htmlspecialchars calls with self::sanitize throughout rendering to avoid charset/encoding issues and ensure consistent escaping; minor UI/drag-and-drop markup tweaks. TextRenderer: injects a leading '^_' for implicit subfield lines to preserve compatibility with legacy JavaScript that expects that marker. Change-log comments were added to headers where relevant.