### PR TITLE
Data entry improvements

### DIFF
--- a/www/htdocs/central/dataentry/dibujarhojaentrada.php
+++ b/www/htdocs/central/dataentry/dibujarhojaentrada.php
@@ -1089,4 +1089,4 @@ function PrepararFormato()
 		}
 	});
 </script>
-<script src="editor/js/clear_field.js"></script>
+<script src="../dataentry/editor/js/clear_field.js"></script>

--- a/www/htdocs/central/dataentry/dirs_explorer.php
+++ b/www/htdocs/central/dataentry/dirs_explorer.php
@@ -5,6 +5,7 @@
 20220214 fho4abcd Change DOCUMENT_ROOT in $db_path, better indicator for ROOT, allow %path_database%, don't show dr_path for explorar
 20220224 fho4abcd Function CopiarImagen: fixed form->supplied form + always close on trigger
 20260522 rogercgui Critical fix: Added missing $db_path definition in the file, which is essential for determining the correct directory paths for file operations. This variable is typically defined in the included config.php, but it was not being set in this script, leading to errors when trying to access or manipulate files. The fix ensures that $db_path is properly initialized from the configuration, allowing the script to function correctly when handling file uploads and directory exploration.
+20260627 rogercgui Enhancement: Improved the file upload process to handle Windows-style paths more robustly. The script now uses json_encode to safely encode the source path, preventing issues with backslashes and special characters in file paths. This change ensures that file uploads work correctly across different operating systems, particularly when dealing with Windows paths that may contain backslashes or other problematic characters.
 */
 
 session_start();
@@ -206,7 +207,7 @@ if (trim($source) != "") {
 		echo "<input type=hidden name=folder>\n";
 		echo "</form>";
 
-		// CORREÇÃO: Fechar as tags HTML para a tela não ficar com visual quebrado
+		// Close the HTML tags so that the screen doesn’t look broken
 		echo "</div></div></body></html>";
 
 		die;
@@ -214,7 +215,7 @@ if (trim($source) != "") {
 		//==============function=========================
 		function Encabezamiento()
 		{
-			global $tag, $msgstr, $arrHttp, $targetForm;
+			global $tag, $msgstr, $arrHttp, $targetForm, $source;
 
 		?>
 			<title><?php echo $msgstr["explore"]; ?></title>
@@ -225,14 +226,21 @@ if (trim($source) != "") {
 						var field = window.opener.document.<?php echo $targetForm; ?>.<?php echo $tag ?>;
 						var campo = field.value;
 
-						// Se for um Textarea (Repetível/Múltiplo), anexa com quebra de linha
+						var relativePath = <?php echo json_encode($source); ?>;
+						var finalImg = Img;
+
+						if (relativePath !== "" && finalImg.indexOf(relativePath) !== 0) {
+							finalImg = relativePath + finalImg;
+						}
+
+						// If it is a Textarea (Repeatable/Multiple), append with a line break
 						if (field.tagName === 'TEXTAREA') {
-							if (campo === "") field.value = Img;
-							else field.value = campo + "\n" + Img;
+							if (campo === "") field.value = finalImg;
+							else field.value = campo + "\n" + finalImg;
 						} else {
-							// Se for um Input (Simples/Único), apenas substitui o valor
-							field.value = Img;
-							self.close(); // Fecha automaticamente porque só cabe um arquivo!
+							// If it is an Input (Simple/Single), it simply replaces the value
+							field.value = finalImg;
+							self.close();
 						}
 					}
 				<?php } ?>
@@ -332,9 +340,9 @@ if (trim($source) != "") {
 						var formData = new FormData();
 						formData.append('arquivo_upload_ajax', file);
 
-						formData.append('base', '<?php echo isset($arrHttp["base"]) ? $arrHttp["base"] : ""; ?>');
-						formData.append('path', '<?php echo isset($arrHttp["path"]) ? $arrHttp["path"] : ""; ?>');
-						formData.append('source', '<?php echo isset($arrHttp["source"]) ? $arrHttp["source"] : ""; ?>');
+						formData.append('base', <?php echo isset($arrHttp["base"]) ? json_encode($arrHttp["base"]) : '""'; ?>);
+						formData.append('path', <?php echo isset($arrHttp["path"]) ? json_encode($arrHttp["path"]) : '""'; ?>);
+						formData.append('source', <?php echo isset($arrHttp["source"]) ? json_encode($arrHttp["source"]) : '""'; ?>);
 
 						var container = document.getElementById('uploadProgressContainer');
 						var bar = document.getElementById('uploadProgressBar');
@@ -343,7 +351,7 @@ if (trim($source) != "") {
 						container.style.display = 'block';
 
 						var xhr = new XMLHttpRequest();
-						
+
 						xhr.open('POST', window.location.href, true);
 
 						xhr.upload.onprogress = function(e) {
@@ -365,9 +373,16 @@ if (trim($source) != "") {
 										if (res.status === 'success') {
 											status.innerText = '<?php echo $msgstr["upload_complete"] ?? "Upload complete! Updating folder..."; ?>';
 											bar.style.background = '#005aa9';
+
+											<?php if (isset($tag) and trim($tag) != "") { ?>
+												if (typeof CopiarImagen === 'function') {
+													CopiarImagen(res.file);
+												}
+											<?php } ?>
+
 											setTimeout(function() {
 												window.location.reload();
-											}, 600);
+											}, 800);
 										} else {
 											alert("<?php echo $msgstr['server_error'] ?? 'Server Error: '; ?>" + res.message);
 											container.style.display = 'none';

--- a/www/htdocs/central/dataentry/editor/renderers/UploadRenderer.php
+++ b/www/htdocs/central/dataentry/editor/renderers/UploadRenderer.php
@@ -5,6 +5,11 @@
  * Author: Roger C. Guilherme
  * Created: 2026-05-02
  * * Description: Unified modular renderer for Upload fields (Type U) with CSS, JS, and Translations
+ * 
+ * changes:
+ * 2026-05-02 rogercgui: Initial version
+ * 2026-06-05 rogercgui: Added support for subdirectory input in the modal and improved error handling
+ * 2026-06-27 rogercgui: Added logic to avoid duplicating the subdirectory in the filename if it is already included
  */
 
 
@@ -92,6 +97,7 @@ class UploadRenderer
         $str_error_server = $msgstr["error_server"] ?? "Server Communication Error";
         $str_error_parse = $msgstr["error_parse"] ?? "Invalid response from the server. The file may exceed the PHP size limit, or the destination folder does not have write permissions.";
         $str_details = $msgstr["details"] ?? "Server error details:";
+        $str_storein = $msgstr["storein"] ?? "Subdirectory / Destination (optional):";
 
 ?>
 
@@ -281,6 +287,10 @@ class UploadRenderer
                             <button type='button' class='abcd-modal-close' onclick='document.getElementById("abcdUploadModal").remove()'>&times;</button>
                         </div>
                         <div class='abcd-modal-body'>
+                            <div style='margin-bottom: 15px;'>
+                                <label style='font-size: 13px; font-weight: bold; color: #555; display: block; margin-bottom: 5px;'><?php echo $str_storein; ?></label>
+                                <input type='text' id='abcdStoreIn_` + tagId + `' placeholder='Ex: ebooks/1/' style='width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;'>
+                            </div>
                             <input type='file' id='abcdFileInput_` + tagId + `' ` + multipleAttr + ` style='display:none' onchange='ABCD_handleFileSelect(this, "` + tagId + `")'>
                             <div class='abcd-modal-dropzone' id='abcdDropzone_` + tagId + `' onclick='document.getElementById("abcdFileInput_" + "` + tagId + `").click()'>
                                 <i class='fas fa-cloud-upload-alt'></i>
@@ -339,7 +349,15 @@ class UploadRenderer
 
             function ABCD_uploadFileAjax(filesArray, tagId, wrapperElement = null, isFromModal = false) {
                 let baseName = (typeof top.base !== 'undefined') ? top.base : (document.forma1 && document.forma1.base ? document.forma1.base.value : '');
-                let storein = (typeof top.img_dir !== 'undefined') ? top.img_dir : '';
+
+                // Capture the subdirectory entered in the modal (if it exists)
+                let modalStoreIn = document.getElementById('abcdStoreIn_' + tagId);
+                let storein = modalStoreIn ? modalStoreIn.value.trim() : '';
+
+                // Fallback to the system global variable if the field is empty
+                if (storein === '' && typeof top.img_dir !== 'undefined') {
+                    storein = top.img_dir;
+                }
 
                 let formData = new FormData();
                 for (let i = 0; i < filesArray.length; i++) {
@@ -380,15 +398,33 @@ class UploadRenderer
                             if (response.success) {
                                 let inputField = document.getElementById(tagId);
                                 if (inputField) {
+
+                                    // Reconstruct the relative path and place it alongside the file
+                                    let pathPrefix = '';
+                                    if (storein !== '') {
+                                        pathPrefix = storein;
+                                        if (pathPrefix.charAt(pathPrefix.length - 1) !== '/') {
+                                            pathPrefix += '/';
+                                        }
+                                    }
+
+                                    let newNamesArray = response.filenames.map(function(name) {
+                                        // Only add the folder if it isn’t included by default
+                                        if (pathPrefix !== "" && name.indexOf(pathPrefix) !== 0) {
+                                            return pathPrefix + name;
+                                        }
+                                        return name;
+                                    });
+                                    let newNames = newNamesArray.join('\n');
+
                                     if (inputField.tagName === 'TEXTAREA') {
-                                        let newNames = response.filenames.join('\n');
                                         if (inputField.value.trim() !== '') {
                                             inputField.value += '\n' + newNames;
                                         } else {
                                             inputField.value = newNames;
                                         }
                                     } else {
-                                        inputField.value = response.filenames[0];
+                                        inputField.value = newNamesArray[0];
                                     }
 
                                     inputField.dispatchEvent(new Event('change', {


### PR DESCRIPTION

Corrects the relative path for the clear_field.js script from 'editor/js/clear_field.js' to '../dataentry/editor/js/clear_field.js' to ensure proper resource resolution.

----

Added a subdirectory/destination input field in the upload modal, allowing users to specify where files should be stored. The upload logic now captures the modal input, with fallback to the system global variable if empty. Implemented path deduplication logic to prevent duplicating the subdirectory in filenames if already included.

----

Fix path handling and security in file upload
Improve file upload functionality by:

- Add $source to global variables for proper path context in Encabezamiento()
- Use json_encode() for FormData parameters instead of direct string concatenation for security
- Implement relative path handling for uploaded files
- Call CopiarImagen() after successful upload to update image fields
- Increase reload timeout from 600ms to 800ms for better reliability
- Update comments from Portuguese to English for consistency
- Minor code cleanup (trailing whitespace removal)