### PR TITLE
Improves circulation

### DIFF
--- a/www/htdocs/assets/css/main.css
+++ b/www/htdocs/assets/css/main.css
@@ -376,7 +376,79 @@ a.singleButton:hover {
     transform: translateY(-2px);
 }
 
-/* Estilos Específicos */
+
+/* BUTTONS WITH FONTAWESOME */
+
+.menuButton-fa {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    width: 240px;
+    /* Standard width of the ABCD buttons */
+    min-height: 65px;
+    background-color: var(--abcd-white, #ffffff);
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+    margin: 5px 15px 15px 0;
+    text-decoration: none !important;
+    /* Anula sublinhado padrão do link */
+    color: var(--abcd-steel-blue, #336699);
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+    box-sizing: border-box;
+    vertical-align: top;
+}
+
+.menuButton-fa:hover,
+.menuButton-fa:focus {
+    background-color: var(--abcd-gray-100, #f8f9fa);
+    border-color: var(--abcd-blue, #003366);
+    text-decoration: none !important;
+    /* Prevents the hover effect from causing the text to be underlined */
+}
+
+.menuButton-fa i {
+    font-size: 24px;
+    width: 50px;
+    /* Fixed space so that the icon does not push the text out of place */
+    text-align: center;
+    flex-shrink: 0;
+    color: inherit;
+}
+
+.menuButton-fa span {
+    font-size: 85%;
+    line-height: 1.3;
+    padding-right: 10px;
+    display: block;
+    float: none;
+    margin: 0;
+    width: auto;
+}
+
+/* SECTION TITLE */
+.homepage .mainBox .boxContent .sectionTitleIcons {
+    position: relative !important;
+    /* Anula o absolute do main.css */
+    top: auto !important;
+    display: flex !important;
+    align-items: center;
+    padding: 0 0 15px 0 !important;
+    width: 100%;
+}
+
+.homepage .mainBox .boxContent .sectionTitleIcons h1 {
+    margin: 0 !important;
+}
+
+/* Alignment of icons in section headings*/
+.loanSection .sectionTitleIcons i {
+    font-size: 24px;
+    margin-right: 10px;
+    color: inherit;
+}
+
+/* Specific Styles */
 a.singleButton {
     display: block;
     float: left;
@@ -1451,12 +1523,6 @@ a.CatexploreButton {
     background-color: var(--abcd-white);
 }
 
-a.origendatabaseButton {
-    background: url('../images/icon/basededatosorigen.png') no-repeat center;
-    background-size: 44px;
-    background-position: 10px;
-    background-color: var(--abcd-white);
-}
 
 /* --- 6.2. Ícones de Circulação --- */
 a.exploreButton {
@@ -1567,48 +1633,6 @@ a.reportsButton {
 
 a.reserveButton {
     background: url('../svg/main/main_book_clock_32_regular.svg') no-repeat left;
-    background-size: 44px;
-    background-position: 10px;
-    background-color: var(--abcd-white);
-}
-
-a.usersconfigureButton {
-    background: url('../images/icon/usersconfigure.png') no-repeat center;
-    background-size: 44px;
-    background-position: 10px;
-    background-color: var(--abcd-white);
-}
-
-a.userstypeButton {
-    background: url('../images/icon/userstype.png') no-repeat center;
-    background-size: 44px;
-    background-position: 10px;
-    background-color: var(--abcd-white);
-}
-
-a.itemstypeButton {
-    background: url('../images/icon/itemstype.png') no-repeat center;
-    background-size: 44px;
-    background-position: 10px;
-    background-color: var(--abcd-white);
-}
-
-a.currency_daysButton {
-    background: url('../images/icon/currency_days.png') no-repeat center;
-    background-size: 44px;
-    background-position: 10px;
-    background-color: var(--abcd-white);
-}
-
-a.calendarButton {
-    background: url('../images/icon/calendar.png') no-repeat center;
-    background-size: 44px;
-    background-position: 10px;
-    background-color: var(--abcd-white);
-}
-
-a.loanpolicyButton {
-    background: url('../images/icon/loanpolicy.png') no-repeat center;
     background-size: 44px;
     background-position: 10px;
     background-color: var(--abcd-white);
@@ -1751,10 +1775,6 @@ a.checkButton img {
     background: url('../images/icon/clean.png') no-repeat center;
 }
 
-a.discardButton img {
-    background: url('../images/icon/trashcan_full.png') no-repeat center;
-}
-
 a.copiesdbaddButton img {
     background: url('../images/icon/db_update.png') no-repeat center;
 }
@@ -1765,10 +1785,6 @@ a.purchaseorderButton img {
 
 a.receiptsButton img {
     background: url('../images/icon/receipts.png') no-repeat center;
-}
-
-a.homeButton img {
-    background: url('../../images/icon/home.png') no-repeat center;
 }
 
 
@@ -2233,18 +2249,6 @@ body:first-of-type .homepage .mainBox .boxContent .searchTitles .stInput input.t
 
 .homepage .mainBox .searchSection .sectionIcon {
     background: url('../images/search.png') no-repeat center;
-}
-
-.homepage .mainBox .orderSection .sectionIcon {
-    background: url('../images/icon/mainBox_titleSection.png') no-repeat center;
-}
-
-.homepage .mainBox .fascicleSection .sectionIcon {
-    background: url('../images/icon/mainBox_fascicleSection.png') no-repeat center;
-}
-
-.homepage .mainBox .maskSection .sectionIcon {
-    background: url('../images/icon/mainBox_maskSection.png') no-repeat center;
 }
 
 .homepage .mainBox .helpSection .sectionIcon {

--- a/www/htdocs/assets/css/odds.css
+++ b/www/htdocs/assets/css/odds.css
@@ -128,22 +128,6 @@ a.textBot:hover {
 		background: url('../images/search.png') no-repeat center;
 	}
 
-	.homepage .mainBox .orderSection .sectionIcon {
-		background: url('../images/icon/mainBox_titleSection.png') no-repeat center;
-	}
-
-	.homepage .mainBox .fascicleSection .sectionIcon {
-		background: url('../images/icon/mainBox_fascicleSection.png') no-repeat center;
-	}
-
-	.homepage .mainBox .maskSection .sectionIcon {
-		background: url('../images/icon/mainBox_maskSection.png') no-repeat center;
-	}
-
-	.homepage .mainBox .toolSection .sectionIcon {
-		background: url('../images/icon/mainBox_toolSection.png') no-repeat center;
-	}
-
 	.homepage .mainBox .loanSection .sectionIcon {
 		background: url('../images/icon/mainBox_loanSection.png') no-repeat center;
 	}
@@ -155,7 +139,6 @@ a.textBot:hover {
 	.homepage .mainBox .boxContent .sectionButtons A.defaultButton {
 		color: #000;
 	}
-
 
 	.homepage .mainBox .boxContent .sectionButtons A.menuButton {
 		color: #000;

--- a/www/htdocs/assets/js/main.js
+++ b/www/htdocs/assets/js/main.js
@@ -38,3 +38,59 @@ function CambiarLenguaje() {
     // Redirects the page
     window.location.href = currentUrl.toString();
 }
+
+
+// ==========================================================================
+// 3. ABCD GRID TABLES (Move, Delete, Duplicate, Add Row)
+// ==========================================================================
+
+// Moves the line up (-1) or down (1)
+function moveRow(btn, direction) {
+    var row = btn.closest("tr");
+    var tbody = row.parentNode;
+    if (direction === -1 && row.previousElementSibling) {
+        tbody.insertBefore(row, row.previousElementSibling);
+    } else if (direction === 1 && row.nextElementSibling) {
+        tbody.insertBefore(row.nextElementSibling, row);
+    }
+}
+
+// Delete the line (prompt for an optional confirmation message)
+function deleteRow(btn, confirmMsg) {
+    if (confirmMsg) {
+        if (!confirm(confirmMsg)) return;
+    }
+    var row = btn.closest("tr");
+    row.remove();
+}
+
+// Duplicates the row and preserves ALL values, regardless of the field name
+function duplicateRow(btn) {
+    var row = btn.closest("tr");
+    var clone = row.cloneNode(true);
+
+    // Copies the values from input fields, select elements and text areas dynamically
+    var origElements = row.querySelectorAll("input, select, textarea");
+    var cloneElements = clone.querySelectorAll("input, select, textarea");
+
+    for (var i = 0; i < origElements.length; i++) {
+        cloneElements[i].value = origElements[i].value;
+    }
+
+    row.parentNode.insertBefore(clone, row.nextSibling);
+}
+
+// Adds a new line based on a hidden ‘Template’ in the HTML
+function addEmptyRow(tbodyId, templateId, position) {
+    var tbody = document.getElementById(tbodyId);
+    var template = document.getElementById(templateId);
+
+    // Clone the template’s content
+    var clone = template.content.cloneNode(true);
+
+    if (position === 'BEFORE' && tbody.firstChild) {
+        tbody.insertBefore(clone, tbody.firstChild);
+    } else {
+        tbody.appendChild(clone);
+    }
+}

--- a/www/htdocs/central/circulation/adm_typeofitems.php
+++ b/www/htdocs/central/circulation/adm_typeofitems.php
@@ -1,164 +1,182 @@
 <?php
 /* Modifications
-2021-02-09 fho4abcd Original name for dhtmlX.js
 2024-04-01 fho4abcd stylesheet from assets + setImagePath + redesign to remove the mix of html and dhtmlx script
+2026-06-28 rogercgui Refactored: Removed dhtmlXGrid, native HTML table with generic JS, PRG pattern added, UI fixes
 */
-/* See https://docs.dhtmlx.com/api__dhtmlxgrid_addrow.html
-*/
+
 session_start();
-if (!isset($_SESSION["permiso"])){
-	header("Location: ../common/error_page.php") ;
+if (!isset($_SESSION["permiso"])) {
+	header("Location: ../common/error_page.php");
 }
-if (!isset($_SESSION["lang"]))  $_SESSION["lang"]="en";
+
+if (!isset($_SESSION["lang"]))  $_SESSION["lang"] = "en";
 include("../common/get_post.php");
 include("../config.php");
-$lang=$_SESSION["lang"];
+$lang = $_SESSION["lang"];
 
 include("../lang/dbadmin.php");
 include("../lang/prestamo.php");
 
-//foreach ($arrHttp as $var=>$value) echo "$var = $value<br>";
 include("../common/header.php");
-?>
-<body>
-<link rel="stylesheet" type="text/css" href="/assets/css/dhtmlXGrid.css">
-<script src="../dataentry/js/dhtml_grid/dhtmlX.js"></script>
-<script src="../dataentry/js/lr_trim.js"></script>
-<script>
-	function AgregarFila(ixfila,Option){
-		switch (Option){
-			case "BEFORE":
-				ixf=mygrid.getRowsNum()+1
-				ref=ixf
-				break
-			case "AFTER":
-				ixf=mygrid.getRowsNum()+2
-				ref=ixf-1
-				break
-			default:
-				ixf=mygrid.getRowsNum()+2
-				break
-		}
-		mygrid.addRow((new Date()).valueOf(),['',''],ixfila)
-       	mygrid.selectRow(ixfila);
-	}
-	function Capturar_Grid(){
-		cols=mygrid.getColumnCount()
-		rows=mygrid.getRowsNum()
-		VC=""
-		for (i=0;i<rows;i++){
-			if (Trim(mygrid.cells2(i,0).getValue())!=""){
-				if (VC!="") VC=VC+"\n"
-				for (j=0;j<cols;j++){
-					cell=mygrid.cells2(i,j).getValue()
-					if (j!=13) VC=VC+cell+'|'
-				}
-			}
-		}
-		return VC
-	}
-	function Enviar(){
-		document.forma1.ValorCapturado.value=Capturar_Grid()
-		document.forma1.submit()
-	}
-</script>
-<?php
-$encabezado="";
+
+$encabezado = "";
 include("../common/institutional_info.php");
 ?>
+<script src="../dataentry/js/abcd_grid.js"></script>
+
 <div class="sectionInfo">
 	<div class="breadcrumb">
-    <?php echo $msgstr["typeofitems"];?>
+		<?php echo $msgstr["typeofitems"]; ?>
 	</div>
 	<div class="actions">
-	<?php
-		$ayuda="/circulation/loans_typeofitems.html";
-		$backtocancelscript="configure_menu.php?encabezado=s";
-		$savescript="javascript:Enviar()";
-		include "../common/inc_cancel.php";
+		<?php
+		$ayuda = "/circulation/loans_typeofitems.html";
+		$backtoscript = "configure_menu.php?encabezado=s";
+		$savescript = "javascript:Enviar()";
+		include "../common/inc_back.php";
 		include "../common/inc_save.php";
-	?>
-    </div>
-    <div class="spacer">&#160;</div>
+		?>
+	</div>
+	<div class="spacer">&#160;</div>
 </div>
+
+<?php include "../common/inc_div-helper.php"; ?>
+
 <?php
-include "../common/inc_div-helper.php";
+// Visual success indicator for the PRG, correctly positioned and with Auto-Hide enabled
+if (isset($_GET['msg']) && $_GET['msg'] == 'success') {
 ?>
+	<div id="msg-success" style="background-color: var(--abcd-green, #28a745); color: white; padding: 12px 20px; margin: 15px; border-radius: 4px; text-align: center; font-size: 14px; font-weight: bold; box-shadow: 0 2px 4px rgba(0,0,0,0.1); transition: opacity 0.5s ease;">
+		<i class="fas fa-check-circle" style="margin-right: 8px;"></i> <?php echo isset($msgstr["updated"]) ? $msgstr["updated"] : "Dados salvos com sucesso!"; ?>
+	</div>
+	<script>
+		setTimeout(function() {
+			var msgDiv = document.getElementById('msg-success');
+			if (msgDiv) {
+				msgDiv.style.opacity = '0';
+				setTimeout(function() {
+					msgDiv.style.display = 'none';
+				}, 500);
+			}
+			// Clears the URL silently to prevent the message from reappearing when you press F5
+			window.history.replaceState({}, document.title, window.location.pathname);
+		}, 3000);
+	</script>
+<?php
+}
+?>
+
 <div class="middle form">
 	<div class="formContent">
-	<br>
-	<a class="bt bt-blue mb-2" href="javascript:void(0)" onclick="AgregarFila(mygrid.getRowIndex(mygrid.getSelectedId()),'BEFORE')">
-		<?php echo $msgstr["addrowbef"]?>
-	</a>
-	<a class="bt bt-blue mb-2" href="javascript:void(0)" onclick="AgregarFila(mygrid.getRowIndex(mygrid.getSelectedId())+1,'AFTER')">
-		<?php echo $msgstr["addrowaf"]?>
-	</a>
-	<a class="bt bt-red mb-2" href="javascript:void(0)" onclick="mygrid.deleteSelectedItem()">
-		<?php echo $msgstr["remselrow"]?>
-	</a><br>
-	<span class="bt-disabled"><i class="fas fa-info-circle"></i> <?php echo $msgstr['double_click']?></span><br>
-	<span class="bt-disabled"><i class="fas fa-info-circle"></i> <?php echo $msgstr['picklist_sort']?></span><br>
-	<span class="bt-disabled"><i class="fas fa-info-circle"></i> <?php echo $msgstr['picklist_move']?></span><br>
-	<?php
-	unset($fp);
-	$archivo=$db_path."circulation/def/".$_SESSION["lang"]."/items.tab" ;
-	if (!file_exists($archivo)) $archivo=$db_path."circulation/def/".$lang_db."/items.tab" ;
-	if (file_exists($archivo))	{
-		$fp=file($archivo);
-	}else{
-		$fp=array();
-		for ($i=0;$i<20;$i++){
-			$fp[$i]=' |';
+		<br>
+		<a class="bt bt-blue mb-2" href="javascript:void(0)" onclick="addEmptyRow('fstBody', 'rowTemplate', 'BEFORE')">
+			<i class="fas fa-plus"></i> <?php echo $msgstr["addrowbef"] ?>
+		</a>
+		<a class="bt bt-blue mb-2" href="javascript:void(0)" onclick="addEmptyRow('fstBody', 'rowTemplate', 'AFTER')">
+			<i class="fas fa-plus"></i> <?php echo $msgstr["addrowaf"] ?>
+		</a>
+		<br><br>
+
+		<?php
+		unset($fp);
+		$archivo = $db_path . "circulation/def/" . $_SESSION["lang"] . "/items.tab";
+		if (!file_exists($archivo)) $archivo = $db_path . "circulation/def/" . $lang_db . "/items.tab";
+		if (file_exists($archivo)) {
+			$fp = file($archivo);
+		} else {
+			$fp = array();
+			for ($i = 0; $i < 5; $i++) {
+				$fp[$i] = '||';
+			}
 		}
-	}
-	?>
-<!-- A div that serves as container for the grid Object. Siz is not very important -->
-<div id="gridbox" xwidth="100px" height="100px" style="background-color:white;"></div>
+		?>
+
+		<form name="typeofitems_form" id="typeofitemsForm" method="post" onsubmit="return false;">
+			<div class="row m-0">
+				<div class="col-12 p-0">
+					<table class="table striped table-fst" id="fstTable" style="width: 100%;">
+						<thead>
+							<tr>
+								<th width="30%"><?php echo $msgstr["item"]; ?></th>
+								<th width="55%"><?php echo $msgstr["description"]; ?></th>
+								<th width="15%" style="text-align: center;"><?php echo $msgstr["actions"] ?? "Ações"; ?></th>
+							</tr>
+						</thead>
+						<tbody id="fstBody">
+							<?php
+							foreach ($fp as $value) {
+								$value = trim($value);
+								if ($value === "") continue;
+
+								$value .= "||"; // Ensures the minimum separators
+								$t = explode("|", $value);
+								$item = trim($t[0] ?? "");
+								$description = trim($t[1] ?? "");
+
+								echo "<tr class='fst-row'>";
+								echo "<td><input type='text' name='row_item' value='" . $item . "' style='width: 100%; box-sizing: border-box;'></td>";
+								echo "<td><input type='text' name='row_description' value='" . $description . "' style='width: 100%; box-sizing: border-box;'></td>";
+
+								echo "<td class='actions-cell' style='text-align: center;'>";
+								echo "<button type='button' class='bt bt-gray' onclick='moveRow(this, -1)'><i class='fas fa-arrow-up'></i></button> ";
+								echo "<button type='button' class='bt bt-gray' onclick='moveRow(this, 1)'><i class='fas fa-arrow-down'></i></button> ";
+								echo "<button type='button' class='bt bt-blue' onclick='duplicateRow(this)'><i class='far fa-copy'></i></button> ";
+								echo "<button type='button' class='bt bt-red' onclick='deleteRow(this)'><i class='fas fa-trash-alt'></i></button>";
+								echo "</td>";
+								echo "</tr>";
+							}
+							?>
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</form>
+
+		<form name="forma1" action="typeofitems_update.php" method="post">
+			<input type="hidden" name="ValorCapturado">
+			<input type="hidden" name="desc">
+			<input type="hidden" name="Opcion" value="">
+			<input type="hidden" name="base" value="items">
+		</form>
+
+	</div>
+</div>
+
+<template id="rowTemplate">
+	<tr class="fst-row">
+		<td><input type="text" name="row_item" value="" style="width: 100%; box-sizing: border-box;"></td>
+		<td><input type="text" name="row_description" value="" style="width: 100%; box-sizing: border-box;"></td>
+		<td class="actions-cell" style="text-align: center;">
+			<button type="button" class="bt bt-gray" onclick="moveRow(this, -1)"><i class="fas fa-arrow-up"></i></button>
+			<button type="button" class="bt bt-gray" onclick="moveRow(this, 1)"><i class="fas fa-arrow-down"></i></button>
+			<button type="button" class="bt bt-blue" onclick="duplicateRow(this)"><i class="far fa-copy"></i></button>
+			<button type="button" class="bt bt-red" onclick="deleteRow(this)"><i class="fas fa-trash-alt"></i></button>
+		</td>
+	</tr>
+</template>
 
 <script>
-    var mygrid = new dhtmlXGridObject('gridbox');
-	mygrid.setImagePath("/assets/images/dhtml_grid/imgs/");
-	mygrid.setHeader("<?php echo $msgstr["item"];?>,<?php echo $msgstr["description"]?>");
+	function Capturar_Grid() {
+		var rows = document.querySelectorAll(".fst-row");
+		var VC = "";
 
-	mygrid.setInitWidths("200,400")
-	mygrid.setColAlign("left,left")
-	mygrid.setColTypes("ed,ed");
-	mygrid.setColSorting("str,str")
-    mygrid.enableAutoHeight(true,800);
-	mygrid.enableAutoWidth(true);
-    mygrid.enableDragAndDrop(true);
-	mygrid.init();
-	index=-1;
-	<?php
-	$t=array();
-	foreach ($fp as $value){
-		$value=trim($value);
-		$value.="||";
-		if (trim($value)!=""){
-			$value=str_replace("'","\'",$value);
-			$t=explode("|",$value);
-			if (!isset($t[0])) $t[0]="";
-			if (!isset($t[1])) $t[1]="";
-			$t[0]=trim($t[0]);
-			$t[1]=trim($t[1]);
-			?>
-			index++;
-			/*first parameter must be unique, also for fast processors*/
-			mygrid.addRow((new Date()).valueOf()+index,['<?php echo $t[0]?>','<?php echo $t[1]?>'],index)
-			<?php
-		}
+		rows.forEach(function(row) {
+			var item = row.querySelector("input[name='row_item']").value.trim();
+			var description = row.querySelector("input[name='row_description']").value.trim();
+
+			if (item !== "") {
+				if (VC !== "") VC += "\n";
+				VC += item + "|" + description + "|";
+			}
+		});
+
+		return VC;
 	}
-	?>
-	mygrid.clearSelection()
-	mygrid.setSizes();
-	mygrid.setColWidth(0,60)
+
+	function Enviar() {
+		document.forma1.ValorCapturado.value = Capturar_Grid();
+		document.forma1.submit();
+	}
 </script>
-<form name="forma1" action="typeofitems_update.php" method="post">
-	<input type="hidden" name="ValorCapturado">
-	<input type="hidden" name="desc">
-	<input type="hidden" name="Opcion" value="">
-	<input type="hidden" name="base" value="users">
-</form>
-</div>
-</div>
+
 <?php include("../common/footer.php"); ?>

--- a/www/htdocs/central/circulation/adm_typeofusers.php
+++ b/www/htdocs/central/circulation/adm_typeofusers.php
@@ -1,178 +1,191 @@
 <?php
 /* Modifications
-2021-02-09 fho4abcd Original name for dhtmlX.js
 2024-04-01 fho4abcd stylesheet from assets + setImagePath + redesign to remove the mix of html and dhtmlx script
+2026-06-28 rogercgui Refactored: Removed dhtmlXGrid, native HTML table with generic JS, PRG pattern added, UI fixes
 */
-/* See https://docs.dhtmlx.com/api__dhtmlxgrid_addrow.html
-*/
+
 session_start();
-if (!isset($_SESSION["permiso"])){
-	header("Location: ../common/error_page.php") ;
+if (!isset($_SESSION["permiso"])) {
+	header("Location: ../common/error_page.php");
 }
-if (!isset($_SESSION["lang"]))  $_SESSION["lang"]="en";
+if (!isset($_SESSION["lang"]))  $_SESSION["lang"] = "en";
 include("../common/get_post.php");
 include("../config.php");
-$lang=$_SESSION["lang"];
+$lang = $_SESSION["lang"];
 
 include("../lang/dbadmin.php");
 include("../lang/prestamo.php");
 
-//foreach ($arrHttp as $var=>$value) echo "$var = $value<br>";
-
 include("../common/header.php");
-?>
-<body>
-<link rel="stylesheet" type="text/css" href="/assets/css/dhtmlXGrid.css">
-<script src="../dataentry/js/dhtml_grid/dhtmlX.js"></script>
-<script src="../dataentry/js/lr_trim.js"></script>
-<script>
-	function AgregarFila(ixfila,Option){
-		switch (Option){
-			case "BEFORE":
-				ixf=mygrid.getRowsNum()+1
-				ref=ixf
-				break
-			case "AFTER":
-				ixf=mygrid.getRowsNum()+2
-				ref=ixf-1
-				break
-			default:
-				ixf=mygrid.getRowsNum()+2
-				break
-		}
-		mygrid.addRow((new Date()).valueOf(),['','',''],ixfila)
-       	mygrid.selectRow(ixfila);
-	}
-	function Capturar_Grid(){
-		cols=mygrid.getColumnCount()
-		rows=mygrid.getRowsNum()
-		VC=""
-		for (i=0;i<rows;i++){
-			if (Trim(mygrid.cells2(i,0).getValue())!=""){
-				if (VC!="") VC=VC+"\n"
-				for (j=0;j<cols;j++){
-					cell=mygrid.cells2(i,j).getValue()
-					if (j!=13) VC=VC+cell+'|'
-				}
-			}
-		}
-		return VC
-	}
-	function Enviar(){
-		document.forma1.ValorCapturado.value=Capturar_Grid()
-		document.forma1.submit()
-	}
-</script>
 
-<?php
-$encabezado="";
+$encabezado = "";
 include("../common/institutional_info.php");
 ?>
+<script src="../dataentry/js/abcd_grid.js"></script>
+
 <div class="sectionInfo">
 	<div class="breadcrumb">
-    <?php echo $msgstr["typeofusers"];?>
+		<?php echo $msgstr["typeofusers"]; ?>
 	</div>
 	<div class="actions">
-<?php
-	$ayuda="/circulation/loans_typeofusers.html";
-    $backtocancelscript="configure_menu.php?encabezado=s";
-	$savescript="javascript:Enviar()";
-    include "../common/inc_cancel.php";
-    include "../common/inc_save.php";
-?>
-    </div>
-    <div class="spacer">&#160;</div>
+		<?php
+		$ayuda = "/circulation/loans_typeofusers.html";
+		$backtoscript = "configure_menu.php?encabezado=s";
+		$savescript = "javascript:Enviar()";
+		include "../common/inc_back.php";
+		include "../common/inc_save.php";
+		?>
+	</div>
+	<div class="spacer">&#160;</div>
 </div>
+
+<?php include "../common/inc_div-helper.php"; ?>
+
 <?php
-include "../common/inc_div-helper.php";
+// Aviso visual de sucesso do PRG posicionado corretamente e com Auto-Hide
+if (isset($_GET['msg']) && $_GET['msg'] == 'success') {
 ?>
+	<div id="msg-success" style="background-color: var(--abcd-green, #28a745); color: white; padding: 12px 20px; margin: 15px; border-radius: 4px; text-align: center; font-size: 14px; font-weight: bold; box-shadow: 0 2px 4px rgba(0,0,0,0.1); transition: opacity 0.5s ease;">
+		<i class="fas fa-check-circle" style="margin-right: 8px;"></i> <?php echo isset($msgstr["updated"]) ? $msgstr["updated"] : "Dados salvos com sucesso!"; ?>
+	</div>
+	<script>
+		setTimeout(function() {
+			var msgDiv = document.getElementById('msg-success');
+			if (msgDiv) {
+				msgDiv.style.opacity = '0';
+				setTimeout(function() {
+					msgDiv.style.display = 'none';
+				}, 500);
+			}
+			// Limpa a URL silenciosamente
+			window.history.replaceState({}, document.title, window.location.pathname);
+		}, 3000);
+	</script>
+<?php
+}
+?>
+
 <div class="middle form">
 	<div class="formContent">
-	<br>
-		<a class="bt bt-blue mb-2" href="javascript:void(0)" onclick="AgregarFila(mygrid.getRowIndex(mygrid.getSelectedId()),'BEFORE')">
-			<?php echo $msgstr["addrowbef"]?>
+		<br>
+		<a class="bt bt-blue mb-2" href="javascript:void(0)" onclick="addEmptyRow('fstBody', 'rowTemplate', 'BEFORE')">
+			<i class="fas fa-plus"></i> <?php echo $msgstr["addrowbef"] ?>
 		</a>
-		<a class="bt bt-blue mb-2" href="javascript:void(0)" onclick="AgregarFila(mygrid.getRowIndex(mygrid.getSelectedId())+1,'AFTER')">
-			<?php echo $msgstr["addrowaf"]?>
+		<a class="bt bt-blue mb-2" href="javascript:void(0)" onclick="addEmptyRow('fstBody', 'rowTemplate', 'AFTER')">
+			<i class="fas fa-plus"></i> <?php echo $msgstr["addrowaf"] ?>
 		</a>
-		<a class="bt bt-red mb-2" href="javascript:void(0)" onclick="mygrid.deleteSelectedItem()">
-			<?php echo $msgstr["remselrow"]?>
-		</a><br>
-	<span class="bt-disabled"><i class="fas fa-info-circle"></i> <?php echo $msgstr['double_click']?></span><br>
-	<span class="bt-disabled"><i class="fas fa-info-circle"></i> <?php echo $msgstr['picklist_sort']?></span><br>
-	<span class="bt-disabled"><i class="fas fa-info-circle"></i> <?php echo $msgstr['picklist_move']?></span><br>
-<?php
+		<br><br>
 
-	unset($fp);
-	$archivo=$db_path."circulation/def/".$_SESSION["lang"]."/typeofusers.tab";
-	if (!file_exists($archivo)) $archivo=$db_path."circulation/def/".$lang_db."/typeofusers.tab";
-	if (file_exists($archivo)){
-		$fp=file($archivo);
-	}else{
-		$fp=array();
-		for ($i=0;$i<10;$i++){
-			$fp[$i]='|||||';
+		<?php
+		unset($fp);
+		$archivo = $db_path . "circulation/def/" . $_SESSION["lang"] . "/typeofusers.tab";
+		if (!file_exists($archivo)) $archivo = $db_path . "circulation/def/" . $lang_db . "/typeofusers.tab";
+		if (file_exists($archivo)) {
+			$fp = file($archivo);
+		} else {
+			$fp = array();
+			for ($i = 0; $i < 5; $i++) {
+				$fp[$i] = '|||||';
+			}
 		}
-	}
-?>
-	<!-- A div that serves as container for the grid Object. Siz is not very important -->
-	<div id="gridbox" xwidth="100px" height="100px" style="background-color:white;"></div>
-	<script>
-    var mygrid = new dhtmlXGridObject('gridbox');
+		?>
 
-	mygrid.setImagePath("/assets/images/dhtml_grid/imgs/");
-	mygrid.setHeader(
-		"<?php echo $msgstr["usertype"];?>,<?php echo $msgstr["description"]?>,<?php echo $msgstr["tit_np"]?>,<?php echo $msgstr["web_reserve"]?>");
-	mygrid.setInitWidths("100,200,50,50")
-	mygrid.setColAlign("left,left,justify,center")
-	mygrid.setColTypes("ed,ed,ed,ed");
-    mygrid.enableAutoWidth(true);
-    mygrid.enableAutoHeight(true,800);
- 	mygrid.setColSorting("str,str,int,int")
-    mygrid.enableDragAndDrop(true);
-	mygrid.init();
-	index=-1;
-	<?php
-	$t=array();
-	foreach ($fp as $value){
-		$value=trim($value);
-		$value.="||||";
-		if (trim($value)!=""){
-			$value=str_replace("'","\'",$value);
-			$t=explode("|",$value);
-			if (!isset($t[0])) $t[0]="";
-			$t[0]=trim($t[0]);
-			$t[1]=trim($t[1]);
-			$t[2]=trim($t[2]);
-			$t[3]=trim($t[3]);
-			?>
-			index++;
-			/*first parameter must be unique, also for fast processors*/
-			mygrid.addRow((new Date()).valueOf()+index,['<?php echo $t[0]?>','<?php echo $t[1]?>','<?php echo $t[2]?>','<?php echo $t[3]?>'],index)
-			<?php
-		}
+		<form name="typeofusers_form" id="typeofusersForm" method="post" onsubmit="return false;">
+			<div class="row m-0">
+				<div class="col-12 p-0">
+					<table class="table striped table-fst" id="fstTable" style="width: 100%;">
+						<thead>
+							<tr>
+								<th width="20%"><?php echo $msgstr["usertype"]; ?></th>
+								<th width="45%"><?php echo $msgstr["description"]; ?></th>
+								<th width="10%" style="text-align: center;"><?php echo $msgstr["tit_np"]; ?></th>
+								<th width="10%" style="text-align: center;"><?php echo $msgstr["web_reserve"]; ?></th>
+								<th width="15%" style="text-align: center;"><?php echo $msgstr["actions"] ?? "Ações"; ?></th>
+							</tr>
+						</thead>
+						<tbody id="fstBody">
+							<?php
+							foreach ($fp as $value) {
+								$value = trim($value);
+								if ($value === "") continue;
+
+								$value .= "||||";
+								$t = explode("|", $value);
+								$usertype = trim($t[0] ?? "");
+								$description = trim($t[1] ?? "");
+								$tit_np = trim($t[2] ?? "");
+								$web_reserve = trim($t[3] ?? "");
+
+								echo "<tr class='fst-row'>";
+								echo "<td><input type='text' name='row_usertype' value='" . $usertype . "' style='width: 100%; box-sizing: border-box;'></td>";
+								echo "<td><input type='text' name='row_description' value='" . $description . "' style='width: 100%; box-sizing: border-box;'></td>";
+								echo "<td><input type='text' name='row_tit_np' value='" . $tit_np . "' style='width: 100%; box-sizing: border-box; text-align: center;'></td>";
+								echo "<td><input type='text' name='row_web_reserve' value='" . $web_reserve . "' style='width: 100%; box-sizing: border-box; text-align: center;'></td>";
+
+								echo "<td class='actions-cell' style='text-align: center;'>";
+								echo "<button type='button' class='bt bt-gray' onclick='moveRow(this, -1)'><i class='fas fa-arrow-up'></i></button> ";
+								echo "<button type='button' class='bt bt-gray' onclick='moveRow(this, 1)'><i class='fas fa-arrow-down'></i></button> ";
+								echo "<button type='button' class='bt bt-blue' onclick='duplicateRow(this)'><i class='far fa-copy'></i></button> ";
+								echo "<button type='button' class='bt bt-red' onclick='deleteRow(this)'><i class='fas fa-trash-alt'></i></button>";
+								echo "</td>";
+								echo "</tr>";
+							}
+							?>
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</form>
+
+		<form name="forma1" action="typeofusers_update.php" method="post">
+			<input type="hidden" name="ValorCapturado">
+			<input type="hidden" name="desc">
+			<input type="hidden" name="Opcion" value="">
+			<input type="hidden" name="base" value="users">
+		</form>
+
+	</div>
+</div>
+
+<template id="rowTemplate">
+	<tr class="fst-row">
+		<td><input type="text" name="row_usertype" value="" style="width: 100%; box-sizing: border-box;"></td>
+		<td><input type="text" name="row_description" value="" style="width: 100%; box-sizing: border-box;"></td>
+		<td><input type="text" name="row_tit_np" value="" style="width: 100%; box-sizing: border-box; text-align: center;"></td>
+		<td><input type="text" name="row_web_reserve" value="" style="width: 100%; box-sizing: border-box; text-align: center;"></td>
+		<td class="actions-cell" style="text-align: center;">
+			<button type="button" class="bt bt-gray" onclick="moveRow(this, -1)"><i class="fas fa-arrow-up"></i></button>
+			<button type="button" class="bt bt-gray" onclick="moveRow(this, 1)"><i class="fas fa-arrow-down"></i></button>
+			<button type="button" class="bt bt-blue" onclick="duplicateRow(this)"><i class="far fa-copy"></i></button>
+			<button type="button" class="bt bt-red" onclick="deleteRow(this)"><i class="fas fa-trash-alt"></i></button>
+		</td>
+	</tr>
+</template>
+
+<script>
+	function Capturar_Grid() {
+		var rows = document.querySelectorAll(".fst-row");
+		var VC = "";
+
+		rows.forEach(function(row) {
+			var usertype = row.querySelector("input[name='row_usertype']").value.trim();
+			var description = row.querySelector("input[name='row_description']").value.trim();
+			var tit_np = row.querySelector("input[name='row_tit_np']").value.trim();
+			var web_reserve = row.querySelector("input[name='row_web_reserve']").value.trim();
+
+			if (usertype !== "") {
+				if (VC !== "") VC += "\n";
+				VC += usertype + "|" + description + "|" + tit_np + "|" + web_reserve + "|";
+			}
+		});
+
+		return VC;
 	}
-	?>
-	mygrid.clearSelection()
-	mygrid.setColWidth(2,80)
-	mygrid.setColWidth(3,80)
-	mygrid.setSizes();
+
+	function Enviar() {
+		document.forma1.ValorCapturado.value = Capturar_Grid();
+		document.forma1.submit();
+	}
 </script>
-<br><br>
-</form>
-<form name=forma1 action=typeofusers_update.php method=post>
-<input type=hidden name=ValorCapturado>
-<input type=hidden name=desc>
-<input type=hidden name=Opcion value=>
-<input type=hidden name=base value=users>
-</form>
 
-
-
-<?php
-
-echo "</div></div></div>";
-include("../common/footer.php");
-echo "</body></html>" ;
-
-?>
+<?php include("../common/footer.php"); ?>

--- a/www/htdocs/central/circulation/configure_menu.php
+++ b/www/htdocs/central/circulation/configure_menu.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @program:   ABCD - ABCD-Central - https://abcd-community.org
  * @file:      configure_menu.php
@@ -7,13 +8,15 @@
  * @since:     20091203
  * @version:   2.2
  *
-*/
+ * changelog:
+ * 2026-06-07 rogercgui Refactored circulation configure menu to use Font Awesome icons instead of image tags for better consistency and maintainability.
+ */
 session_start();
-if (!isset($_SESSION["permiso"])){
-	header("Location: ../common/error_page.php") ;
+if (!isset($_SESSION["permiso"])) {
+	header("Location: ../common/error_page.php");
 }
-if (!isset($_SESSION["lang"]))  $_SESSION["lang"]="en";
-$lang=$_SESSION["lang"];
+if (!isset($_SESSION["lang"]))  $_SESSION["lang"] = "en";
+$lang = $_SESSION["lang"];
 include("../common/get_post.php");
 include("../config.php");
 include("../lang/admin.php");
@@ -22,26 +25,24 @@ include("../lang/prestamo.php");
 
 //foreach ($arrHttp as $var=>$value) echo "$var = $value<br>";
 include("../common/header.php");
-$encabezado="";
-$encabezado="&encabezado=s";
+$encabezado = "";
+$encabezado = "&encabezado=s";
 ?>
-
-<body>
 
 <?php include("../common/institutional_info.php"); ?>
 
-	<div class="sectionInfo">
+<div class="sectionInfo">
 	<div class="breadcrumb">
-		<?php echo $msgstr["configure"];?>
+		<?php echo $msgstr["configure"]; ?>
 	</div>
 	<div class="actions">
 	</div>
-	<?php include("submenu_prestamo.php");?>
+	<?php include("submenu_prestamo.php"); ?>
 </div>
 
 
 <?php
-$ayuda="configure_menu.html";
+$ayuda = "configure_menu.html";
 include "../common/inc_div-helper.php";
 ?>
 
@@ -49,47 +50,55 @@ include "../common/inc_div-helper.php";
 <div class="middle homepage">
 
 
-<div class="mainBox" >
-	<div class="boxContent loanSection">
-		<div class="sectionTitle">
-		<img src="../../assets/svg/circ/ic_fluent_database_24_regular.svg">
-			<h1><?php echo $msgstr["policy"]?></h1>
-		</div>
-		<div class="sectionButtons">
+	<div class="mainBox">
+		<div class="boxContent loanSection">
+			<div class="sectionTitleIcons">
+				<i class="fas fa-cogs"></i>
+				<h1><?php echo $msgstr["policy"] ?></h1>
+			</div>
+			<div class="sectionButtons">
 
-				<a href="adm_databases.php" class="menuButton multiLine origendatabaseButton">
-					<span><strong><?php echo $msgstr["sourcedb"]?></strong></span>
+				<a href="adm_databases.php" class="menuButton-fa">
+					<i class="fas fa-database"></i>
+					<span><strong><?php echo $msgstr["sourcedb"] ?></strong></span>
 				</a>
-				<a href="borrowers_configure.php" class="menuButton multiLine usersconfigureButton">
-					<span><strong><?php echo $msgstr["bconf"]?></strong></span>
+				<a href="borrowers_configure.php" class="menuButton-fa">
+					<i class="fas fa-users-cog"></i>
+					<span><strong><?php echo $msgstr["bconf"] ?></strong></span>
 				</a>
-				<a href="adm_typeofusers.php" class="menuButton multiLine userstypeButton">
-					<span><strong><?php echo $msgstr["typeofusers"]?></strong></span>
+				<a href="adm_typeofusers.php" class="menuButton-fa">
+					<i class="fas fa-user-tag"></i>
+					<span><strong><?php echo $msgstr["typeofusers"] ?></strong></span>
 				</a>
-    				<a href="adm_typeofitems.php" class="menuButton multiLine itemstypeButton">
-					<span><strong><?php echo $msgstr["typeofitems"]?></strong></span>
+				<a href="adm_typeofitems.php" class="menuButton-fa">
+					<i class="fas fa-tags"></i>
+					<span><strong><?php echo $msgstr["typeofitems"] ?></strong></span>
 				</a>
-    			<a href="adm_loanobjects.php" class="menuButton multiLine loanpolicyButton">
-					<span><strong><?php echo $msgstr["objectpolicy"]?></strong></span>
-				</a>
-
-				<a href="adm_form_locales.php" class="menuButton multiLine currency_daysButton">
-					<span><strong><?php echo $msgstr["local"]?></strong></span>
-				</a>
-
-				<a href="adm_calendario.php" class="menuButton multiLine calendarButton">
-					<span><strong><?php echo $msgstr["calendar"]?></strong></span>
+				<a href="adm_loanobjects.php" class="menuButton-fa">
+					<i class="fas fa-sliders-h"></i>
+					<span><strong><?php echo $msgstr["objectpolicy"] ?></strong></span>
 				</a>
 
-           		<a href="sala_configure.php" class="menuButton multiLine loanpolicyButton">
-					<span><strong><?php echo $msgstr["sala"]?></strong></span>
+				<a href="adm_form_locales.php" class="menuButton-fa">
+					<i class="fas fa-coins"></i>
+					<span><strong><?php echo $msgstr["local"] ?></strong></span>
 				</a>
-				<?php if (isset($ILL)){
+
+				<a href="adm_calendario.php" class="menuButton-fa">
+					<i class="fas fa-calendar-alt"></i>
+					<span><strong><?php echo $msgstr["calendar"] ?></strong></span>
+				</a>
+
+				<a href="sala_configure.php" class="menuButton-fa">
+					<i class="fas fa-book-reader"></i>
+					<span><strong><?php echo $msgstr["sala"] ?></strong></span>
+				</a>
+				<?php if (isset($ILL)) {
 				?>
-				<a href="../circulation/interbib_configure.php?encabezado=s" class="menuButton providersButton">
-	
-							<span><strong><?php echo $msgstr["r_ill"]?></strong></span>
-						</a>
+					<a href="../circulation/interbib_configure.php?encabezado=s" class="menuButton-fa">
+						<i class="fas fa-handshake"></i>
+						<span><strong><?php echo $msgstr["r_ill"] ?></strong></span>
+					</a>
 				<?php
 				}
 				?>
@@ -101,25 +110,29 @@ include "../common/inc_div-helper.php";
 	</div>
 
 
-<div class="mainBox" >
-	<div class="boxContent loanSection">
-		<div class="sectionTitle">
-		<img src="../../assets/svg/circ/ic_fluent_database_24_regular.svg">
-			<h1><?php echo $msgstr["outputs"]?></h1>
-		</div>
-		<div class="sectionButtons">
+	<div class="mainBox">
+		<div class="boxContent loanSection">
+			<div class="sectionTitleIcons">
+				<i class="fas fa-print"></i>
+				<h1><?php echo $msgstr["outputs"] ?></h1>
+			</div>
+			<div class="sectionButtons">
 
-				<a href="../circulation/receipts.php?base=trans&encabezado=s&retorno=../circulation/configure_menu.php" class="menuButton multiLine reportsButton">
-					<span><strong><?php echo $msgstr["receipts"]?></strong></span>
+				<a href="../circulation/receipts.php?base=trans&encabezado=s&retorno=../circulation/configure_menu.php" class="menuButton-fa">
+					<i class="fas fa-receipt"></i>
+					<span><strong><?php echo $msgstr["receipts"] ?></strong></span>
 				</a>
-				<a href="../dbadmin/pft.php?base=trans&encabezado=s&retorno=../circulation/configure_menu.php" class="menuButton multiLine reportsButton">
-					<span><strong><?php echo $msgstr["reports_trans"]?></strong></span>
+				<a href="../dbadmin/pft.php?base=trans&encabezado=s&retorno=../circulation/configure_menu.php" class="menuButton-fa">
+					<i class="fas fa-exchange-alt"></i>
+					<span><strong><?php echo $msgstr["reports_trans"] ?></strong></span>
 				</a>
-				<a href="../dbadmin/pft.php?base=suspml&encabezado=s&retorno=../circulation/configure_menu.php" class="menuButton multiLine reportsButton">
-					<span><strong><?php echo $msgstr["reports_suspml"]?></strong></span>
+				<a href="../dbadmin/pft.php?base=suspml&encabezado=s&retorno=../circulation/configure_menu.php" class="menuButton-fa">
+					<i class="fas fa-user-slash"></i>
+					<span><strong><?php echo $msgstr["reports_suspml"] ?></strong></span>
 				</a>
-				<a href="../dbadmin/pft.php?base=users&encabezado=s&retorno=../circulation/configure_menu.php" class="menuButton multiLine reportsButton">
-					<span><strong><?php echo $msgstr["reports_borrowers"]?></strong></span>
+				<a href="../dbadmin/pft.php?base=users&encabezado=s&retorno=../circulation/configure_menu.php" class="menuButton-fa">
+					<i class="fas fa-users"></i>
+					<span><strong><?php echo $msgstr["reports_borrowers"] ?></strong></span>
 				</a>
 
 
@@ -127,15 +140,18 @@ include "../common/inc_div-helper.php";
 			<div class="spacer">&#160;</div>
 		</div>
 
-			<div class="spacer">&#160;</div>
+		<div class="spacer">&#160;</div>
 
 	</div>
 </div>
 <form name=admin method=post action=administrar_ex.php onSubmit="Javascript:return false">
-<input type=hidden name=base>
-<input type=hidden name=cipar>
-<input type=hidden name=Opcion>
+	<input type=hidden name=base>
+	<input type=hidden name=cipar>
+	<input type=hidden name=Opcion>
 </form>
 </div>
 </div>
-<?php include("../common/footer.php");?>
+<?php include("../common/footer.php"); ?>
+</body>
+
+</html>

--- a/www/htdocs/central/circulation/configure_menu.php
+++ b/www/htdocs/central/circulation/configure_menu.php
@@ -6,7 +6,7 @@
  * @desc:      Configuration menu
  * @author:    Guilda Ascencio
  * @since:     20091203
- * @version:   2.2
+ * @version:   3.8.4
  *
  * changelog:
  * 2026-06-07 rogercgui Refactored circulation configure menu to use Font Awesome icons instead of image tags for better consistency and maintainability.

--- a/www/htdocs/central/circulation/estado_de_cuenta.php
+++ b/www/htdocs/central/circulation/estado_de_cuenta.php
@@ -14,6 +14,8 @@ include("../lang/prestamo.php");
 //foreach ($arrHttp as $var=>$value) echo "$var = $value<br>";
 include("../common/header.php");
 
+
+
 function LeerPft($pft_name, $base)
 {
 	global $arrHttp, $db_path, $lang_db;
@@ -123,7 +125,7 @@ $codigo = LeerPft("loans_uskey.pft", "users");
 	}
 
 	function Output(code, name) {
-		document.getElementById('loading').style.display = 'block';
+		//document.getElementById('preloader').style.display = 'block';
 		if (Trim(document.usersearch.usercode.value) != "")
 			document.output.user.value = document.usersearch.usercode.value
 		for (i = 0; i < document.inventorysearch.sort.length; i++) {
@@ -134,6 +136,7 @@ $codigo = LeerPft("loans_uskey.pft", "users");
 		document.output.action = "../output_circulation/" + name + ".php"
 		document.output.code.value = code
 		document.output.name.value = name
+		document.output.target = "receiver"
 		document.output.submit()
 	}
 </script>
@@ -254,7 +257,7 @@ include "../common/inc_div-helper.php";
 	<input type="hidden" name="lang" value="<?php echo $lang; ?>">
 	<input type="hidden" name="reserva" value="S">
 </form>
-<?php include("../common/footer.php");
+<?php 
 echo "</body></html>";
 if (isset($arrHttp["error"]) and $arrHttp["inventory"] != "") {
 	echo "
@@ -263,4 +266,6 @@ if (isset($arrHttp["error"]) and $arrHttp["inventory"] != "") {
 	</script>
 	";
 }
+
+include("../common/footer.php");
 ?>

--- a/www/htdocs/central/circulation/typeofitems_update.php
+++ b/www/htdocs/central/circulation/typeofitems_update.php
@@ -1,51 +1,24 @@
 <?php
 session_start();
-if (!isset($_SESSION["permiso"])){
-	header("Location: ../common/error_page.php") ;
+if (!isset($_SESSION["permiso"])) {
+	header("Location: ../common/error_page.php");
+	exit;
 }
 include("../common/get_post.php");
 include("../config.php");
-$lang=$_SESSION["lang"];
-include("../lang/prestamo.php");
 
-//foreach ($arrHttp as $var => $value) 	echo "$var = $value<br>";
-$arrHttp["ValorCapturado"]= htmlspecialchars_decode ($arrHttp["ValorCapturado"]);
-$arrHttp["ValorCapturado"]= stripslashes ($arrHttp["ValorCapturado"]);
-$t=explode("\n",$arrHttp["ValorCapturado"]);
-$fp=fopen($db_path."circulation/def/".$_SESSION["lang"]."/items.tab","w");
-foreach ($t as $value){
-	fwrite($fp,stripslashes($value)."\n");
+// Recolhe os dados e processa a gravação
+$arrHttp["ValorCapturado"] = stripslashes($arrHttp["ValorCapturado"] ?? "");
+$t = explode("\n", $arrHttp["ValorCapturado"]);
+$fp = fopen($db_path . "circulation/def/" . $_SESSION["lang"] . "/items.tab", "w");
+
+if ($fp) {
+	foreach ($t as $value) {
+		fwrite($fp, stripslashes($value) . "\n");
+	}
+	fclose($fp);
 }
-include("../common/header.php");
 
-echo "<body>";
-include("../common/institutional_info.php");
-?>
-<div class="sectionInfo">
-	<div class="breadcrumb">
-<?php echo $msgstr["typeofitems"]?>
-	</div>
-
-	<div class="actions">
-		<a href="configure_menu.php" class="defaultButton backButton">
-		<img src="../../assets/images/defaultButton_iconBorder.gif" alt="" title="" />
-		<span><strong><?php echo $msgstr["back"]?></strong></span>
-		</a>
-	</div>
-	<div class="spacer">&#160;</div>
-</div>
-<div class="helper">
-<?php if ($_SESSION["permiso"]=="admloan") echo "<font color=white>&nbsp; &nbsp; Script: typeofitems_update.php" ?></font>
-	</div>
-<div class="middle form">
-			<div class="formContent">
-<center><h4>
-<?php echo $msgstr["typeofitems"]." ".$msgstr["saved"]?>!!!!</h4>
-
-		</TD>
-</table>
-</center>
-</div></div>
-<?php include("../common/footer.php");?>
-</body>
-</html>
+// Redirects the user back to the list page with a success message
+header("Location: adm_typeofitems.php?msg=success");
+exit;

--- a/www/htdocs/central/circulation/typeofusers_update.php
+++ b/www/htdocs/central/circulation/typeofusers_update.php
@@ -1,50 +1,24 @@
 <?php
 session_start();
-if (!isset($_SESSION["permiso"])){
-	header("Location: ../common/error_page.php") ;
+if (!isset($_SESSION["permiso"])) {
+	header("Location: ../common/error_page.php");
+	exit;
 }
 include("../common/get_post.php");
 include("../config.php");
-$lang=$_SESSION["lang"];
-include("../lang/prestamo.php");
-//foreach ($arrHttp as $var => $value) 	echo "$var = $value<br>";die;
-$arrHttp["ValorCapturado"]= htmlspecialchars_decode ($arrHttp["ValorCapturado"]);
-$arrHttp["ValorCapturado"]= stripslashes ($arrHttp["ValorCapturado"]);
-$t=explode("\n",$arrHttp["ValorCapturado"]);
-$fp=fopen($db_path."circulation/def/".$_SESSION["lang"]."/typeofusers.tab","w");
-foreach ($t as $value){
-	fwrite($fp,stripslashes($value)."\n");
+
+// Recupera os dados e processa a gravação
+$arrHttp["ValorCapturado"] = stripslashes($arrHttp["ValorCapturado"] ?? "");
+$t = explode("\n", $arrHttp["ValorCapturado"]);
+$fp = fopen($db_path . "circulation/def/" . $_SESSION["lang"] . "/typeofusers.tab", "w");
+
+if ($fp) {
+	foreach ($t as $value) {
+		fwrite($fp, stripslashes($value) . "\n");
+	}
+	fclose($fp);
 }
-include("../common/header.php");
 
-echo "<body>";
-include("../common/institutional_info.php");
-?>
-<div class="sectionInfo">
-	<div class="breadcrumb">
-<?php echo $msgstr["typeofusers"]?>
-	</div>
-
-	<div class="actions">
-		<a href="configure_menu.php" class="defaultButton backButton">
-		<img src="../../assets/images/defaultButton_iconBorder.gif" alt="" title="" />
-		<span><strong><?php echo $msgstr["back"]?></strong></span>
-		</a>
-	</div>
-	<div class="spacer">&#160;</div>
-</div>
-<div class="helper">
-<?php if ($_SESSION["permiso"]=="admloan") echo "<font color=white>&nbsp; &nbsp; Script: typeofusers_update.php" ?></font>
-	</div>
-<div class="middle form">
-			<div class="formContent">
-<center><h4>
-<?php echo $msgstr["typeofusers"]." ".$msgstr["saved"]?>!!!!</h4>
-
-		</TD>
-</table>
-</center>
-</div></div>
-<?php include("../common/footer.php");?>
-</body>
-</html>
+// O fluxo mágico: Redireciona o usuário de volta para a listagem com a flag de sucesso
+header("Location: adm_typeofusers.php?msg=success");
+exit;

--- a/www/htdocs/central/output_circulation/rs01.php
+++ b/www/htdocs/central/output_circulation/rs01.php
@@ -90,7 +90,7 @@ global $msgstr,$arrHttp,$db_path,$xWxis,$tagisis,$Wxis,$wxisUrl,$lang_db;
 
 include("../common/header.php");
 
-include("../common/institutional_info.php");
+//include("../common/institutional_info.php");
 include("../circulation/scripts_circulation.php");
 ?>
 
@@ -101,10 +101,10 @@ include("../circulation/scripts_circulation.php");
 	</div>
 	<div class="actions">
 		<?php 
-		$backtoscript="../circulation/estado_de_cuenta.php?reserve=S";
-		include "../common/inc_back.php"; ?>
+		//$backtoscript="../circulation/estado_de_cuenta.php?reserve=S";
+		//include "../common/inc_back.php"; ?>
 	</div>
-<?php include("../circulation/submenu_prestamo.php");?>
+<?php //include("../circulation/submenu_prestamo.php");?>
 </div>
 
 <div class="middle form">
@@ -342,9 +342,7 @@ if ($found==0){
 </div>
 
 </div>
-<font size=1 color=#cccccc>reserve_01.pft - tit_reserve_01.tab
 
-<?php include '../common/footer.php';?>
 
 
 

--- a/www/htdocs/central/output_circulation/rsweb.php
+++ b/www/htdocs/central/output_circulation/rsweb.php
@@ -265,7 +265,7 @@ global $msgstr,$arrHttp,$db_path,$xWxis,$tagisis,$Wxis,$wxisUrl,$lang_db,$Pft_ni
 
 include("../common/header.php");
 
-include("../common/institutional_info.php");
+//include("../common/institutional_info.php");
 include("../circulation/scripts_circulation.php");
 
 switch ($arrHttp["code"]){
@@ -302,10 +302,10 @@ switch ($arrHttp["code"]){
 	</div>
 	<div class="actions">
 		<?php 
-		$backtoscript="../circulation/estado_de_cuenta.php?reserve=S";
-		include "../common/inc_back.php"; ?>
+		//$backtoscript="../circulation/estado_de_cuenta.php?reserve=S";
+		//include "../common/inc_back.php"; ?>
 	</div>
-<?php include("../circulation/submenu_prestamo.php");?>
+<?php //include("../circulation/submenu_prestamo.php");?>
 </div>
 
 <div class="middle form">
@@ -585,6 +585,3 @@ function Prestar(inventario,usuario,base,prefijo,formato,copies){
 	document.prestar.submit()
 }
 </script>
-
-
-<?php include '../common/footer.php';?>


### PR DESCRIPTION
[Replace dhtmlXGrid with native HTML tables](https://github.com/ABCD-DEVCOM/ABCD/commit/078abd040bd33b0dcd63da19d8f35a09ae19d253) 

Migrate circulation admin forms (typeofitems and typeofusers) from dhtmlXGrid to native HTML tables with generic JavaScript functions for row management (move, delete, duplicate, add). Implements PRG pattern with success notifications. Removes legacy icon-based CSS classes and simplifies update handlers.

---

[Restructure circulation output pages layout](https://github.com/ABCD-DEVCOM/ABCD/commit/723656c00e3db2dd691d1e9b7c8cd25cfd2fc02e) 

Disable institutional header, navigation, and footer includes in circulation output pages (rs01.php, rsweb.php). Update estado_de_cuenta.php to target output form to 'receiver' frame and reorganize footer include placement. Comment out unused preloader reference.

---

[Use Font Awesome icons and improve code formatting](https://github.com/ABCD-DEVCOM/ABCD/commit/fc9d337e20012407ea51a4b6aea97bbead9dd17b) 

Refactored circulation configure menu to use Font Awesome icons instead of image tags for better consistency and maintainability. Updated button classes to use unified `menuButton-fa` styling. Fixed code formatting including spacing around operators, proper indentation, and added missing HTML closing tags.

---

[Remove unused sectionIcon background rules](https://github.com/ABCD-DEVCOM/ABCD/commit/02364686643b1a089b1ca65c43fab66cfa6118d9) 

Delete background-image rules for .homepage .mainBox .{orderSection, fascicleSection, maskSection, toolSection} .sectionIcon to clean up unused CSS. Also removed an extra blank line. No functional changes expected; this is a cosmetic cleanup of odds.css.