### PR TITLE
Modernize language loading with LanguageManager

### DIFF
--- a/www/htdocs/central/settings/editar_abcd_def.php
+++ b/www/htdocs/central/settings/editar_abcd_def.php
@@ -398,19 +398,27 @@ if (!isset($_SESSION["login"]) or $_SESSION["profile"] != "adm") {
 }
 //$Permiso=$_SESSION["permiso"];
 
-//SE LEE LA LISTA DE MENSAJES DISPONIBLEE
-$l = $msg_path . 'lang/';
-if ($handle = opendir($l)) {
-	$lang_dir = "";
-	while (false !== ($entry = readdir($handle))) {
-		if ($entry != "." and $entry != ".." and is_dir($l . $entry)) {
-			if ($lang_dir == "")
-				$lang_dir = $entry;
-			else
-				$lang_dir .= ";" . $entry;
-		}
-	}
-	closedir($handle);
+// SE LEE LA LISTA DE MENSAJES DISPONIBLES (Modernizado via LanguageManager)
+global $langManager;
+$lang_dir = "";
+
+if (isset($langManager)) {
+    // Carrega a lista oficial de idiomas usando o inglês como fallback
+    $availableLangs = $langManager->loadTranslations('lang.tab', 'en');
+    $langKeys = [];
+    
+    foreach ($availableLangs as $code => $name) {
+        if ($code !== 'lang') {
+            $langKeys[] = $code; // Guarda apenas a sigla (ex: pt, en, es)
+        }
+    }
+    // Transforma o array em uma string separada por ponto-e-vírgula (ex: "en;es;pt")
+    $lang_dir = implode(';', $langKeys);
+}
+
+// Fallback de segurança caso a leitura falhe
+if (empty($lang_dir)) {
+    $lang_dir = "en;es;pt";
 }
 
 // Databases list

--- a/www/htdocs/central/settings/opac/opac_msgs.php
+++ b/www/htdocs/central/settings/opac/opac_msgs.php
@@ -68,7 +68,7 @@ if (file_exists($a)) {
 	}
 }
 
-$a=$path."lang/00/opac.tab";
+$a=$path."lang/en/opac.tab";
 if (file_exists($a)) {
 	$fp=file($a);
 	foreach($fp as $var=>$value){


### PR DESCRIPTION
Replace manual directory scanning with LanguageManager class for loading available languages. Updates language path from '00' to 'en' standard code and adds fallback mechanism to ensure language list is always populated.