### PR TITLE
Show empty-directory notice; add i18n entries

### DIFF
--- a/www/htdocs/central/dataentry/dirs_explorer.class.php
+++ b/www/htdocs/central/dataentry/dirs_explorer.class.php
@@ -195,11 +195,11 @@ global $arrHttp,$img_path,$msgstr,$targetForm;
 			     {$i=2;
 			     Encabezamiento();
 			   }
-				// CORREÇÃO: Avisa visualmente quando o diretório estiver vazio
+
 				if (count($turinys["tipas"]) <= 2 && $root) {
 					echo "<div style='text-align:center; padding: 40px; color:#999;'>";
 					echo "<i class='far fa-folder-open fa-3x'></i><br><br>";
-					echo "O diretório selecionado está vazio.<br><small>Faça o upload de arquivos primeiro.</small></div>";
+					echo $msgstr["empty_dir"] . "<br><small>" . $msgstr["upload_files_first"] . "</small></div>";
 				}
 
 	           for ($i;$i<count($turinys["tipas"]);$i++)

--- a/www/htdocs/central/dataentry/dirs_explorer.php
+++ b/www/htdocs/central/dataentry/dirs_explorer.php
@@ -19,7 +19,6 @@ include("../common/get_post.php");
 include("../config.php");
 //foreach ($arrHttp as $var=>$value) echo "$var=$value<br>";
 
-include("../config.php");
 
 // =========================================================================
 // BUILT-IN AJAX UPLOAD ENGINE (Path + Source Correction)

--- a/www/htdocs/central/lang/en/dbadmin.tab
+++ b/www/htdocs/central/lang/en/dbadmin.tab
@@ -759,3 +759,5 @@ ff_add_category_to=Add New Category to
 ff_add_category=Add Category
 ff_fdt=FDT
 edit_occ=Edit occurrence(s) and subfields
+empty_dir=The selected directory is empty.
+upload_files_first=Please upload files first.

--- a/www/htdocs/central/lang/es/dbadmin.tab
+++ b/www/htdocs/central/lang/es/dbadmin.tab
@@ -414,3 +414,5 @@ ff_no_categories=Ninguna categoría configurada en este archivo. Añada la primera
 ff_add_category_to=Añadir Nueva Categoría al
 ff_add_category=Añadir Categoría
 ff_fdt=FDT
+empty_dir=El directorio seleccionado está vacío.
+upload_files_first=Por favor, suba archivos primero.

--- a/www/htdocs/central/lang/pt/dbadmin.tab
+++ b/www/htdocs/central/lang/pt/dbadmin.tab
@@ -732,3 +732,5 @@ ff_add_category_to=Adicionar Nova Categoria ao
 ff_add_category=Adicionar Categoria
 ff_fdt=FDT
 edit_occ=Editar subcampos
+empty_dir=O diret?rio selecionado est? vazio.
+upload_files_first=Fa?a o upload de arquivos primeiro.


### PR DESCRIPTION
Replace hardcoded empty-directory text in dirs_explorer.class.php with localized $msgstr keys, and add empty_dir and upload_files_first translations to English, Spanish and Portuguese dbadmin.tab files. Also remove a duplicate include("../config.php") in dirs_explorer.php. This makes the empty-folder warning translatable and cleans up a redundant include.