### PR TITLE
Update button onclick handlers in cloned rows

### DIFF
--- a/www/htdocs/central/dataentry/scripts_dataentry.php
+++ b/www/htdocs/central/dataentry/scripts_dataentry.php
@@ -779,6 +779,15 @@ function CancelarActualizacion(){
 			}
 		}
 
+		var buttons = newRow.querySelectorAll('button');
+		for (var i = 0; i < buttons.length; i++) {
+			var btn = buttons[i];
+			var onclickAttr = btn.getAttribute('onclick');
+			if (onclickAttr) {
+				btn.setAttribute('onclick', onclickAttr.replace(tag + "_" + lastIndex, tag + "_" + nextIndex));
+			}
+		}
+
 		tbody.appendChild(newRow);
 	}
 


### PR DESCRIPTION
When a row is duplicated, button onclick attributes need to be updated to reference the new row index instead of the old one. This ensures event handlers in cloned buttons work correctly with the duplicated row's data.