### PR TITLE
Unify search expression building

### DIFF
--- a/www/htdocs/opac/components/facets.php
+++ b/www/htdocs/opac/components/facets.php
@@ -19,7 +19,7 @@
 
 function facetas()
 {
-    global $db_path, $lang, $msgstr, $actparfolder, $xWxis, $busqueda, $Expresion, $primera_base, $ABCD_scripts_path, $IsisScript, $expresion, $base;
+    global $db_path, $lang, $msgstr, $actparfolder, $xWxis, $busqueda, $Expresion, $primera_base, $ABCD_scripts_path, $IsisScript, $expresion, $base, $Web_Dir;
 
     $facetas = "S";
 
@@ -33,12 +33,18 @@ function facetas()
             $bases_para_processar = array_keys($bd_list);
         }
 
-        $expresionOriginal = construir_expresion();
+        // 1. Obtém as facetas ativas da URL (se houver)
+        $Expr_facetas = isset($_REQUEST["facetas"]) && $_REQUEST["facetas"] != "" ? urldecode($_REQUEST["facetas"]) : "";
+
+        // 2. Constrói a expressão usando a Fonte Única de Verdade
+        require_once $Web_Dir . 'includes/search/expression_builder.php';
+        $expresionOriginal = montarExpressaoBusca(construir_expresion(), $Expr_facetas);
 
         $termo_livre = isset($_REQUEST["Sub_Expresion"]) ? urldecode($_REQUEST["Sub_Expresion"]) : "";
         $tem_truncagem = (strpos($termo_livre, '$') !== false);
 
         $expresionSemAcento = removeacentos($expresionOriginal);
+
         $expresionClean = str_replace(['(', ')', '+and+'], ['', '', ') and ('], $expresionSemAcento);
 
         foreach ($bases_para_processar as $base_atual) {

--- a/www/htdocs/opac/includes/search/direct_search.php
+++ b/www/htdocs/opac/includes/search/direct_search.php
@@ -46,8 +46,7 @@ function searchDirect($bd_list, $db_path, $Expresion, $termo_livre, $Expr_faceta
     $sufixo_truncagem = $tem_truncagem ? '$' : '';
 
     // Uso do Helper 1
-    $coleccion_str = isset($_REQUEST["coleccion"]) ? $_REQUEST["coleccion"] : "";
-    $busqueda = build_search_expression($Expresion, $coleccion_str, $Expr_facetas);
+    $busqueda = montarExpressaoBusca($Expresion, $Expr_facetas);
 
     // Uso do Helper 2
     $totals_data = get_wxis_totals($bd_list, $db_path, $busqueda, $sufixo_truncagem);

--- a/www/htdocs/opac/includes/search/expression_builder.php
+++ b/www/htdocs/opac/includes/search/expression_builder.php
@@ -1,16 +1,20 @@
 <?php
+
 /**
  * -------------------------------------------------------------------------
- * Helper: Construtor de Expressão de Busca
+ * Helper: Search Expression Builder
  * Author: Roger C. Guilherme
  * Date: 2026-07-28
+ * Description: Build the final expression by combining the base expression, the collection and the active facets.
+ * A single source is used by buscar_integrada.php and facets.php to ensure consistency.
  * -------------------------------------------------------------------------
  */
-
-function build_search_expression($Expresion, $coleccion_str, $Expr_facetas) {
+function montarExpressaoBusca($Expresion, $Expr_facetas = '')
+{
     $busqueda = $Expresion;
-    if (isset($coleccion_str) and $coleccion_str != "") {
-        $coleccion = explode('|', urldecode($coleccion_str));
+
+    if (isset($_REQUEST["coleccion"]) && $_REQUEST["coleccion"] != "") {
+        $coleccion = explode('|', urldecode($_REQUEST["coleccion"]));
         $col0 = isset($coleccion[0]) ? $coleccion[0] : '';
         $col2 = isset($coleccion[2]) ? $coleccion[2] : '';
 
@@ -20,15 +24,16 @@ function build_search_expression($Expresion, $coleccion_str, $Expr_facetas) {
             $busqueda = $col2 . $col0;
         }
     }
+
     if (!empty($Expr_facetas)) {
         $f = explode('|', $Expr_facetas);
         if (isset($f[1]) && !empty(trim($f[1]))) {
             $exFacetas = trim($f[1]);
-            if ($busqueda == "" || $busqueda == '$') $busqueda = $exFacetas;
-            else $busqueda = "(" . $busqueda . ") and (" . $exFacetas . ")";
+            $busqueda = ($busqueda == "" || $busqueda == '$')
+                ? $exFacetas
+                : "(" . $busqueda . ") and (" . $exFacetas . ")";
         }
     }
-    if (empty($busqueda)) $busqueda = '$';
-    
-    return $busqueda;
+
+    return empty($busqueda) ? '$' : $busqueda;
 }

--- a/www/htdocs/opac/includes/search/organized_search.php
+++ b/www/htdocs/opac/includes/search/organized_search.php
@@ -39,24 +39,7 @@ function searchAndOrganizeResults($bd_list, $db_path, $Expresion, $termo_livre, 
         }
     }
 
-    $busqueda = $Expresion;
-    if (isset($_REQUEST["coleccion"]) and $_REQUEST["coleccion"] != "") {
-        $coleccion = explode('|', urldecode($_REQUEST["coleccion"]));
-        if ($Expresion != "" and $Expresion != '$' and $Expresion != $coleccion[2] . $coleccion[0]) {
-            $busqueda = "(" . $Expresion . ") and (" . $coleccion[2] . $coleccion[0] . ")";
-        } else {
-            $busqueda = $coleccion[2] . $coleccion[0];
-        }
-    }
-    if (!empty($Expr_facetas)) {
-        $f = explode('|', $Expr_facetas);
-        if (isset($f[1]) && !empty(trim($f[1]))) {
-            $exFacetas = trim($f[1]);
-            if ($busqueda == "" || $busqueda == '$') $busqueda = $exFacetas;
-            else $busqueda = "(" . $busqueda . ") and (" . $exFacetas . ")";
-        }
-    }
-    if (empty($busqueda)) $busqueda = '$';
+    $busqueda = montarExpressaoBusca($Expresion, $Expr_facetas);
 
     // STEP 1: GET THE TOTAL
     $total_base = [];


### PR DESCRIPTION
Extract montarExpressaoBusca helper into includes/search/expression_builder.php and refactor facets.php, direct_search.php and organized_search.php to use it. The new helper centralizes combining the base expression, collection and active facets (reads coleccion from request and returns '$' when empty). facets.php now pulls facetas from the request and includes the builder via $Web_Dir. Minor cleanup and formatting improvements to ensure a single source of truth for search expression construction.