### PR TITLE
Sanitize request output to prevent XSS

### DIFF
--- a/www/htdocs/opac/components/facets.php
+++ b/www/htdocs/opac/components/facets.php
@@ -105,13 +105,13 @@ function facetas()
                     }
 
                     $collapse_id = "collapseFacet_" . $base_atual . "_" . $facet_counter;
-                    
+
                     // Conta quantos tipos diferentes de filtros existem nesta faceta
                     $total_termos_faceta = count($ocorrencias);
 
                     // Constrói o HTML da faceta em memória
                     $html_facetas_base .= "<div class='faceta-box mb-2'>";
-                    
+
                     $html_facetas_base .= "<a class='d-flex justify-content-between align-items-center text-decoration-none pb-2 pt-2 border-bottom facet-toggle text-secondary' data-bs-toggle='collapse' href='#" . $collapse_id . "' role='button' aria-expanded='true' aria-controls='" . $collapse_id . "' style='font-size: 0.9rem;'>";
 
                     // Título da faceta (à esquerda). Adicionado text-truncate para prevenir quebra de linha se o título for gigante.
@@ -154,7 +154,7 @@ function facetas()
                 echo "<h6 class='mt-4 mb-2 p-2 bg-light border rounded text-dark fw-bold text-uppercase' style='font-size: 0.85rem; letter-spacing: 0.5px;'>";
                 echo "<i class='fas fa-database me-2 text-secondary'></i>" . $bd_list[$base_atual]['descripcion'];
                 echo "</h6>";
-                
+
                 // Imprime todas as facetas que foram guardadas em memória
                 echo $html_facetas_base;
             }
@@ -218,7 +218,7 @@ if (function_exists('PresentarExpresion')) {
             // =========================================================
 
             // O onclick="" usa o termo TÉCNICO ($termoRaw) para funcionar
-            echo "<button type='button' class='btn btn-outline-primary btn-sm mr-1 mb-1 termo' onclick='removerTermo(\"" . htmlspecialchars($termoRaw) . "\")'>";
+            echo "<button type='button' class='btn btn-outline-primary btn-sm mr-1 mb-1 termo' onclick='removerTermo(\"" . htmlspecialchars($termoRaw, ENT_QUOTES, 'UTF-8') . "\")'>";
 
             // O texto visível do botão usa o termo LIMPO ($termoDisplay)
             echo $termoDisplay;
@@ -242,9 +242,9 @@ if (function_exists('PresentarExpresion')) {
         <input type="hidden" name="Expresion" id="Expresion" value="<?php echo htmlspecialchars($expresion); ?>">
         <input type="hidden" name="Opcion" value="directa">
         <?php if (isset($_REQUEST['base'])) { ?>
-            <input type="hidden" name="base" id="base" value="<?php echo $_REQUEST['base']; ?>">
+            <input type="hidden" name="base" id="base" value="<?php echo htmlspecialchars($_REQUEST['base'], ENT_QUOTES, 'UTF-8'); ?>">
         <?php } ?>
-        <input type="hidden" name="lang" value="<?php echo $_REQUEST['lang']; ?>">
+        <input type="hidden" name="lang" value="<?php echo htmlspecialchars($_REQUEST['lang'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
         <?php if (isset($_REQUEST['indice_base'])) { ?>
             <input type="hidden" name="indice_base" value="<?php echo $_REQUEST['indice_base']; ?>">
         <?php } ?>

--- a/www/htdocs/opac/components/mail_form.php
+++ b/www/htdocs/opac/components/mail_form.php
@@ -1,7 +1,9 @@
 <form name="correo" action="controllers/control_mail.php" method="post" onSubmit='EnviarCorreo();return false'>
 <?php
-foreach ($_REQUEST as $var=>$value){
-	echo "<input type='hidden' name='$var' value='$value'>\n";
+foreach ($_REQUEST as $var => $value) {
+	if (is_string($value)) {
+		echo "<input type='hidden' name='" . htmlspecialchars($var, ENT_QUOTES, 'UTF-8') . "' value='" . htmlspecialchars($value, ENT_QUOTES, 'UTF-8') . "'>\n";
+	}
 }
 ?>
 

--- a/www/htdocs/opac/components/search_detailed.php
+++ b/www/htdocs/opac/components/search_detailed.php
@@ -33,7 +33,7 @@ if (isset($_REQUEST["coleccion"]) and $_REQUEST["coleccion"] != "") {
 	$_REQUEST["coleccion"] = urldecode($_REQUEST["coleccion"]);
 	$col = explode('|', $_REQUEST["coleccion"]);
 	if (isset($col[1])) {
-		echo " <small class='text-muted'>(<strong><i>" . $col[1] . "</i></strong>)</small>";
+		echo " <small class='text-muted'>(<strong><i>" . htmlspecialchars($col[1], ENT_QUOTES, 'UTF-8') . "</i></strong>)</small>";
 	}
 }
 

--- a/www/htdocs/opac/components/search_free.php
+++ b/www/htdocs/opac/components/search_free.php
@@ -27,7 +27,9 @@ if (!isset($titulo_pagina)) {
 				if (isset($_REQUEST["coleccion"]) && $_REQUEST["coleccion"] != "") {
 					$_REQUEST["coleccion"] = urldecode($_REQUEST["coleccion"]);
 					$cc = explode('|', $_REQUEST["coleccion"]);
-					echo " > <i>" . $cc[1] . "</i>";
+					if (isset($cc[1])) {
+						echo " > <i>" . htmlspecialchars($cc[1], ENT_QUOTES, 'UTF-8') . "</i>";
+					}
 				}
 			} else {
 				// Se a base não existe no array, exibe uma mensagem de erro
@@ -47,12 +49,12 @@ if (!isset($mostrar_libre) || $mostrar_libre != "N") {
 			<input type="hidden" name="page" value="startsearch">
 			<input type="hidden" name="target_db" id="target_db_input" value="">
 			<?php
-			if (isset($_REQUEST["db_path"])) echo "<input type=hidden name=db_path value=" . $_REQUEST["db_path"] . ">\n";
-			if (isset($lang)) echo "<input type=hidden name=lang value=" . $lang . ">\n";
-			if (isset($_REQUEST["Formato"])) echo "<input type=hidden name=indice_base value=" . $_REQUEST["Formato"] . ">\n";
-			if (isset($_REQUEST["indice_base"])) echo "<input type=hidden name=indice_base value=" . $_REQUEST["indice_base"] . ">\n";
-			if ($base != "") echo "<input id=base type=hidden name=base value=" . $base . ">\n";
-			if (isset($_REQUEST["modo"])) echo "<input type=hidden name=modo value=" . $_REQUEST["modo"] . ">\n";
+			if (isset($_REQUEST["db_path"])) echo "<input type=hidden name=db_path value=\"" . htmlspecialchars($_REQUEST["db_path"], ENT_QUOTES, 'UTF-8') . "\">\n";
+			if (isset($lang)) echo "<input type=hidden name=lang value=\"" . htmlspecialchars($lang, ENT_QUOTES, 'UTF-8') . "\">\n";
+			if (isset($_REQUEST["Formato"])) echo "<input type=hidden name=indice_base value=\"" . htmlspecialchars($_REQUEST["Formato"], ENT_QUOTES, 'UTF-8') . "\">\n";
+			if (isset($_REQUEST["indice_base"])) echo "<input type=hidden name=indice_base value=\"" . htmlspecialchars($_REQUEST["indice_base"], ENT_QUOTES, 'UTF-8') . "\">\n";
+			if ($base != "") echo "<input id=base type=hidden name=base value=\"" . htmlspecialchars($base, ENT_QUOTES, 'UTF-8') . "\">\n";
+			if (isset($_REQUEST["modo"])) echo "<input type=hidden name=modo value=\"" . htmlspecialchars($_REQUEST["modo"], ENT_QUOTES, 'UTF-8') . "\">\n";
 			if (isset($_REQUEST['Sub_Expresion'])) $_REQUEST['Sub_Expresion'] = urldecode(str_replace('~', '', $_REQUEST['Sub_Expresion']));
 			?>
 
@@ -62,7 +64,7 @@ if (!isset($mostrar_libre) || $mostrar_libre != "N") {
 					type="text"
 					name="Sub_Expresion"
 					id="termo-busca"
-					value="<?php if (isset($_REQUEST['Sub_Expresion'])) echo htmlentities($_REQUEST['Sub_Expresion']); ?>"
+					value="<?php if (isset($_REQUEST['Sub_Expresion'])) echo htmlspecialchars($_REQUEST['Sub_Expresion'], ENT_QUOTES, 'UTF-8'); ?>"
 					placeholder="<?php echo $msgstr["front_search"] ?>  ..."
 					autocomplete="off">
 


### PR DESCRIPTION
Escape user-supplied values with htmlspecialchars (ENT_QUOTES, 'UTF-8') across facetas, mail_form, search_detailed and search_free. Changes: escape button onclick term and hidden inputs in facets.php; only include string request values and escape names/values in mail_form.php; escape collection label in search_detailed.php; escape collection label, several hidden inputs and the Sub_Expresion value in search_free.php. These fixes reduce XSS risk when rendering request data.